### PR TITLE
Separating memory leaks reporting code

### DIFF
--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -519,6 +519,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\core\serialization\TypeConverter.h" />
+    <ClInclude Include="src\instrumentation\MemoryLeaks.h" />
     <ClInclude Include="src\ui\editor\Theme.h" />
     <ClInclude Include="src\utils\StringUtils.h" />
     <ClInclude Include="vendors\ImGuiFileDialog-0.6.3\dirent\dirent.h" />

--- a/Source/Engine.vcxproj.filters
+++ b/Source/Engine.vcxproj.filters
@@ -976,6 +976,7 @@
     <ClInclude Include="src\core\serialization\TypeConverter.h">
       <Filter>Core\Serialization</Filter>
     </ClInclude>
+    <ClInclude Include="src\instrumentation\MemoryLeaks.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Modules">

--- a/Source/src/Main.cpp
+++ b/Source/src/Main.cpp
@@ -1,17 +1,5 @@
 #include "core/hepch.h"
-
-#ifdef _DEBUG
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
-#define _CRTDBG_MAP_ALLOC
-#include <cstdlib>
-#include <crtdbg.h>
-#endif
-
-void DumpLeaks(void)
-{
-    _CrtDumpMemoryLeaks(); // Show leaks with file and line where allocation was made
-}
+#include "instrumentation/MemoryLeaks.h"
 
 enum class MainStates
 {
@@ -27,7 +15,7 @@ Hachiko::Logger* Logging = nullptr;
 
 int main(int argc, char** argv)
 {
-    atexit(DumpLeaks);
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
     Logging = new Hachiko::Logger();
 
     int main_return = EXIT_FAILURE;

--- a/Source/src/instrumentation/MemoryLeaks.h
+++ b/Source/src/instrumentation/MemoryLeaks.h
@@ -1,0 +1,8 @@
+#pragma once
+#ifdef _DEBUG
+#define _CRTDBG_MAP_ALLOC
+#include <cstdlib>
+#include <crtdbg.h>
+#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#define new DEBUG_NEW
+#endif


### PR DESCRIPTION
this extracts the memory leak reporting logic to a separate file