### PR TITLE
Added ComponentTransform logic of Strawhat Engine.

### DIFF
--- a/Source/src/components/ComponentCamera.cpp
+++ b/Source/src/components/ComponentCamera.cpp
@@ -91,9 +91,9 @@ float4x4 Hachiko::ComponentCamera::GetProjectionMatrix(const bool transpose) con
 
 void Hachiko::ComponentCamera::OnTransformUpdated()
 {
-    const ComponentTransform* transform = game_object->GetComponent<ComponentTransform>();
+    const ComponentTransform* transform = game_object->GetTransform();
 
-    frustum.SetFrame(transform->GetPosition(), transform->GetFwd(), transform->GetUp());
+    frustum.SetFrame(transform->GetPosition(), transform->GetFront(), transform->GetUp());
     frustum.GetPlanes(planes);
 }
 

--- a/Source/src/components/ComponentDirLight.cpp
+++ b/Source/src/components/ComponentDirLight.cpp
@@ -27,18 +27,18 @@ void Hachiko::ComponentDirLight::DebugDraw()
 {
     if (draw_direction)
     {
-        auto* transform = game_object->GetComponent<ComponentTransform>();
+        auto* transform = game_object->GetTransform();
         if (transform)
         {
-            dd::arrow(transform->GetPosition(), transform->GetFwd().Mul(3.f) + transform->GetPosition(), dd::colors::Blue, 1.f);
+            dd::arrow(transform->GetPosition(), transform->GetFront().Mul(3.f) + transform->GetPosition(), dd::colors::Blue, 1.f);
         }
     }
 }
 
 float3 Hachiko::ComponentDirLight::GetDirection() const
 {
-    const ComponentTransform* transform = game_object->GetComponent<ComponentTransform>();
-    return transform->GetFwd();
+    const ComponentTransform* transform = game_object->GetTransform();
+    return transform->GetFront();
 }
 
 void Hachiko::ComponentDirLight::Save(JsonFormatterValue j_component) const

--- a/Source/src/components/ComponentMesh.cpp
+++ b/Source/src/components/ComponentMesh.cpp
@@ -33,7 +33,7 @@ void Hachiko::ComponentMesh::Import(const aiMesh* mesh)
 void Hachiko::ComponentMesh::Draw(ComponentCamera* camera, Program* program)
 {
     assert(resource->loaded == true);
-    program->BindUniformFloat4x4("model", &game_object->GetComponent<ComponentTransform>()->GetTransform()[0][0]);
+    program->BindUniformFloat4x4("model", game_object->GetTransform()->GetMatrix().ptr());
 
     const ComponentMaterial* material = game_object->GetComponent<ComponentMaterial>();
     App->program->UpdateMaterial(material);
@@ -45,7 +45,7 @@ void Hachiko::ComponentMesh::Draw(ComponentCamera* camera, Program* program)
 void Hachiko::ComponentMesh::DrawStencil(ComponentCamera* camera, Program* program) const
 {
     assert(resource->loaded == true);
-    program->BindUniformFloat4x4("model", &game_object->GetComponent<ComponentTransform>()->GetTransform()[0][0]);
+    program->BindUniformFloat4x4("model", game_object->GetTransform()->GetMatrix().ptr());
 
     glBindVertexArray(resource->vao);
     glDrawElements(GL_TRIANGLES, resource->buffer_sizes[static_cast<int>(ResourceMesh::Buffers::INDICES)], GL_UNSIGNED_INT, nullptr);

--- a/Source/src/components/ComponentPointLight.cpp
+++ b/Source/src/components/ComponentPointLight.cpp
@@ -26,7 +26,7 @@ void Hachiko::ComponentPointLight::DebugDraw()
 {
     if (draw_sphere)
     {
-        auto* transform = game_object->GetComponent<ComponentTransform>();
+        auto* transform = game_object->GetTransform();
         if (transform)
         {
             dd::sphere(transform->GetPosition(), dd::colors::Blue, radius);
@@ -36,7 +36,7 @@ void Hachiko::ComponentPointLight::DebugDraw()
 
 float3 Hachiko::ComponentPointLight::GetPosition() const
 {
-    const ComponentTransform* transform = game_object->GetComponent<ComponentTransform>();
+    const ComponentTransform* transform = game_object->GetTransform();
     return transform->GetPosition();
 }
 

--- a/Source/src/components/ComponentSpotLight.cpp
+++ b/Source/src/components/ComponentSpotLight.cpp
@@ -26,25 +26,25 @@ void Hachiko::ComponentSpotLight::DebugDraw()
 {
     if (draw_cone)
     {
-        auto* transform = game_object->GetComponent<ComponentTransform>();
+        auto* transform = game_object->GetTransform();
         if (transform)
         {
-            dd::cone(transform->GetPosition(), transform->GetFwd().Mul(radius), dd::colors::Blue, inner, 0.f);
-            dd::cone(transform->GetPosition(), transform->GetFwd().Mul(radius), dd::colors::Green, outer, 0.f);
+            dd::cone(transform->GetPosition(), transform->GetFront().Mul(radius), dd::colors::Blue, inner, 0.f);
+            dd::cone(transform->GetPosition(), transform->GetFront().Mul(radius), dd::colors::Green, outer, 0.f);
         }
     }
 }
 
 float3 Hachiko::ComponentSpotLight::GetPosition() const
 {
-    const ComponentTransform* transform = game_object->GetComponent<ComponentTransform>();
+    const ComponentTransform* transform = game_object->GetTransform();
     return transform->GetPosition();
 }
 
 float3 Hachiko::ComponentSpotLight::GetDirection() const
 {
-    const ComponentTransform* transform = game_object->GetComponent<ComponentTransform>();
-    return transform->GetFwd();
+    const ComponentTransform* transform = game_object->GetTransform();
+    return transform->GetFront();
 }
 
 void Hachiko::ComponentSpotLight::Save(JsonFormatterValue j_component) const

--- a/Source/src/components/ComponentTransform.cpp
+++ b/Source/src/components/ComponentTransform.cpp
@@ -1,141 +1,183 @@
 #include "core/hepch.h"
 #include "ComponentTransform.h"
 
-Hachiko::ComponentTransform::ComponentTransform(GameObject* new_object, float3 position, Quat rotation, float3 scale) :
-    Component(Type::TRANSFORM, new_object),
-    local_position(position),
-    local_scale(scale),
-    local_rotation(rotation)
+Hachiko::ComponentTransform::ComponentTransform(GameObject* container) 
+    : Component(Type::TRANSFORM, container) 
+    , changed(false)
+    , matrix(float4x4::identity)
+    , matrix_local(float4x4::identity)
+    , position(float3::zero)
+    , position_local(float3::zero)
+    , scale(float3::zero)
+    , scale_local(float3::zero)
+    , rotation(Quat::identity)
+    , rotation_local(Quat::identity)
+    , rotation_euler(float3::zero)
+    , rotation_euler_local(float3::zero)
+    , right(float3::unitX)
+    , up(float3::unitY)
+    , front(float3::unitZ)
 {
-    SetLocalTransform(position, rotation, scale);
 }
 
-Hachiko::ComponentTransform::ComponentTransform(GameObject* new_object, const float4x4& new_transform) :
-    Component(Type::TRANSFORM, new_object)
+Hachiko::ComponentTransform::ComponentTransform(GameObject* container, const float3& new_position_local, const Quat& new_rotation_local, const float3& new_scale_local) 
+    : ComponentTransform(container)
 {
-    SetLocalTransform(new_transform);
+    SetLocalTransform(new_position_local, new_rotation_local, new_scale_local);
 }
 
-Hachiko::ComponentTransform::~ComponentTransform() = default;
-
-void Hachiko::ComponentTransform::LookAt(float3 target, float3 world_up)
+Hachiko::ComponentTransform::ComponentTransform(GameObject* container, const float4x4& new_transform_local) 
+    : ComponentTransform(container)
 {
-    const float3 direction = target - GetPosition();
-
-    const float3 fwd = direction.Normalized();
-    const float3 right = world_up.Cross(fwd).Normalized();
-    const float3 up = fwd.Cross(right).Normalized();
-
-    SetRotationAxis(right, up, fwd);
+    SetLocalTransform(new_transform_local);
 }
 
-void Hachiko::ComponentTransform::SetRotationAxis(float3 x, float3 y, float3 z)
+void Hachiko::ComponentTransform::OnTransformUpdated()
 {
-    transform.SetCol3(0, x);
-    transform.SetCol3(1, y);
-    transform.SetCol3(2, z);
-
-    SetGlobalTransform(transform);
+    changed = false;
 }
 
-inline void Hachiko::ComponentTransform::SetLocalTransform(float3 position, Quat rotation, float3 scale)
+inline Quat Hachiko::ComponentTransform::SimulateLookAt(const float3& direction)
 {
-    const float4x4 new_transform = float4x4::FromTRS(position, rotation, scale);
-    SetLocalTransform(new_transform);
+    float3 right_temp = float3::unitY.Cross(direction).Normalized();
+
+    float3 up_temp = direction.Cross(right_temp).Normalized();
+
+    Quat orientation = Quat::LookAt(-float3::unitZ, direction, float3::unitY, float3::unitY);
+
+    return orientation;
 }
 
-inline void Hachiko::ComponentTransform::SetLocalPosition(float3 new_position)
+void Hachiko::ComponentTransform::LookAtTarget(const float3& target)
 {
-    SetLocalTransform(new_position, local_rotation, local_scale);
+    const float3 direction = (GetPosition() - target).Normalized();
+
+    SetRotation(SimulateLookAt(direction));
 }
 
-inline void Hachiko::ComponentTransform::SetLocalScale(float3 new_scale)
+void Hachiko::ComponentTransform::LookAtDirection(const float3& direction) 
 {
-    SetLocalTransform(local_position, local_rotation, new_scale);
+    SetRotation(SimulateLookAt(direction));
 }
 
-inline void Hachiko::ComponentTransform::SetLocalRotation(Quat new_rotation)
+void Hachiko::ComponentTransform::SetGlobalTransform(const float4x4& new_matrix)
 {
-    SetLocalTransform(local_position, new_rotation, local_scale);
+    new_matrix.Decompose(position, rotation, scale);
+    rotation_euler = RadToDeg(rotation.ToEulerXYZ());
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::LOCAL_FROM_GLOBAL);
 }
 
-void Hachiko::ComponentTransform::SetLocalRotation(float3 rotation_angles)
+void Hachiko::ComponentTransform::SetPosition(const float3& new_position) 
 {
-    const float3 rotation = DegToRad(rotation_angles);
-    SetLocalTransform(local_position, Quat::FromEulerXYZ(rotation.x, rotation.y, rotation.z).Normalized(), local_scale);
+    position = new_position;
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::LOCAL_FROM_GLOBAL);
 }
 
-void Hachiko::ComponentTransform::SetLocalTransform(float4x4 new_transform)
+void Hachiko::ComponentTransform::SetScale(const float3& new_scale) 
 {
-    local_transform = new_transform;
-    local_transform.Decompose(local_position, local_rotation, local_scale);
-    local_rotation_euler = RadToDeg(local_rotation.ToEulerXYZ());
+    scale = new_scale;
 
-    UpdateGlobalTransformHierarchy();
+    UpdateTransformOfHierarchy(MatrixCalculationMode::LOCAL_FROM_GLOBAL);
 }
 
-void Hachiko::ComponentTransform::SetGlobalTransform(float4x4 transform)
+void Hachiko::ComponentTransform::SetRotationAxis(const float3& new_right, const float3& new_up, const float3& new_front)
 {
-    // Use parent global transform to get local transform	
+    matrix.SetCol3(0, new_right);
+    matrix.SetCol3(1, new_up);
+    matrix.SetCol3(2, new_front);
 
-    if (game_object->parent)
-    {
-        float4x4 parent_transform = game_object->parent->GetComponent<ComponentTransform>()->GetTransform();
-        parent_transform.Inverse();
-        SetLocalTransform(parent_transform * transform);
-    }
-    else
-        SetLocalTransform(transform);
+    matrix.Decompose(position, rotation, scale);
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::LOCAL_FROM_GLOBAL);
 }
 
-void Hachiko::ComponentTransform::UpdateGlobalTransformHierarchy()
+void Hachiko::ComponentTransform::SetRotation(const Quat& new_rotation)
 {
-    // Updates current transform based on parent and calls to update the children
-    if (game_object->parent)
-    {
-        transform = game_object->parent->GetComponent<ComponentTransform>()->GetTransform() * local_transform;
-    }
-    else
-    {
-        transform = local_transform;
-    }
+    rotation = new_rotation.Normalized();
+    rotation_euler = RadToDeg(rotation.ToEulerXYZ());
 
-    // Set transform as changed
-    changed = true;
-
-    // Update children
-    for (GameObject* child : game_object->children)
-    {
-        child->GetComponent<ComponentTransform>()->UpdateGlobalTransformHierarchy();
-    }
+    UpdateTransformOfHierarchy(MatrixCalculationMode::LOCAL_FROM_GLOBAL);
 }
 
-void Hachiko::ComponentTransform::SetPosition(float3 new_transform)
+void Hachiko::ComponentTransform::SetRotationInEulerAngles(const float3& new_rotation_euler) 
 {
-    transform.SetTranslatePart(new_transform);
-    SetGlobalTransform(transform);
+    float3 delta = DegToRad(new_rotation_euler - rotation_euler);
+    Quat rotation_amount = Quat::FromEulerXYZ(delta.x, delta.y, delta.z).Normalized();
+
+    rotation = rotation_amount * (rotation);
+    rotation_euler = new_rotation_euler;
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::LOCAL_FROM_GLOBAL);
+}
+
+void Hachiko::ComponentTransform::SetLocalTransform(const float4x4& new_transform_local)
+{
+    new_transform_local.Decompose(position_local, rotation_local, scale_local);
+    rotation_euler_local = RadToDeg(rotation_local.ToEulerXYZ());
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::GLOBAL_FROM_LOCAL);
+}
+
+void Hachiko::ComponentTransform::SetLocalTransform(const float3& new_position_local, const Quat& new_rotation_local, const float3& new_scale_local)
+{
+    SetLocalTransform(float4x4::FromTRS(new_position_local, new_rotation_local, new_scale_local));
+}
+
+void Hachiko::ComponentTransform::SetLocalPosition(const float3& new_position_local) 
+{
+    position_local = new_position_local;
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::GLOBAL_FROM_LOCAL);
+}
+
+void Hachiko::ComponentTransform::SetLocalScale(const float3& new_scale_local) 
+{
+    scale_local = new_scale_local;
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::GLOBAL_FROM_LOCAL);
+}
+
+void Hachiko::ComponentTransform::SetLocalRotation(const Quat& new_rotation_local) 
+{
+    rotation_local = new_rotation_local;
+    rotation_euler_local = RadToDeg(rotation_local.ToEulerXYZ());
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::GLOBAL_FROM_LOCAL);
+}
+
+void Hachiko::ComponentTransform::SetLocalRotationInEulerAngles(const float3& new_rotation_euler_local)
+{
+    math::float3 delta = DegToRad(new_rotation_euler_local - rotation_euler_local);
+    math::Quat rotation_amount = math::Quat::FromEulerXYZ(delta.x, delta.y, delta.z);
+
+    rotation_local = rotation_amount * (rotation_local);
+    rotation_euler_local = new_rotation_euler_local;
+
+    UpdateTransformOfHierarchy(MatrixCalculationMode::GLOBAL_FROM_LOCAL);
 }
 
 void Hachiko::ComponentTransform::Save(JsonFormatterValue j_component) const
 {
     const JsonFormatterValue j_position = j_component["Position"];
 
-    j_position[0] = local_position.x;
-    j_position[1] = local_position.y;
-    j_position[2] = local_position.z;
+    j_position[0] = position_local.x;
+    j_position[1] = position_local.y;
+    j_position[2] = position_local.z;
 
     const JsonFormatterValue j_rotation = j_component["Rotation"];
 
-    j_rotation[0] = local_rotation.x;
-    j_rotation[1] = local_rotation.y;
-    j_rotation[2] = local_rotation.z;
-    j_rotation[3] = local_rotation.w;
+    j_rotation[0] = rotation_local.x;
+    j_rotation[1] = rotation_local.y;
+    j_rotation[2] = rotation_local.z;
+    j_rotation[3] = rotation_local.w;
 
     const JsonFormatterValue j_scale = j_component["Scale"];
 
-    j_scale[0] = local_scale.x;
-    j_scale[1] = local_scale.y;
-    j_scale[2] = local_scale.z;
+    j_scale[0] = scale_local.x;
+    j_scale[1] = scale_local.y;
+    j_scale[2] = scale_local.z;
 }
 
 void Hachiko::ComponentTransform::Load(JsonFormatterValue j_component)
@@ -144,43 +186,62 @@ void Hachiko::ComponentTransform::Load(JsonFormatterValue j_component)
     const JsonFormatterValue j_rotation = j_component["Rotation"];
     const JsonFormatterValue j_scale = j_component["Scale"];
 
-    local_position = float3(j_position[0], j_position[1], j_position[2]);
-    local_rotation = Quat(j_rotation[0], j_rotation[1], j_rotation[2], j_rotation[3]);
-    local_scale = float3(j_scale[0], j_scale[1], j_scale[2]);
+    position_local = float3(j_position[0], j_position[1], j_position[2]);
+    rotation_local = Quat(j_rotation[0], j_rotation[1], j_rotation[2], j_rotation[3]);
+    scale_local = float3(j_scale[0], j_scale[1], j_scale[2]);
 
-    SetLocalTransform(local_position, local_rotation, local_scale);
+    SetLocalTransform(position_local, rotation_local, scale_local);
 }
 
 void Hachiko::ComponentTransform::DrawGui()
 {
     static bool locked_scale = true;
     static bool debug_transforms = false;
+    
     if (ImGui::CollapsingHeader("Local Transform", ImGuiTreeNodeFlags_DefaultOpen))
     {
-        float3 position = local_position;
-        float3 scale = local_scale;
-        float3 rotation = local_rotation_euler;
-        if (ImGui::InputFloat3("position", &position[0]))
+        float3 position_local_editor = position_local;
+        float3 scale_local_editor = scale_local;
+        float3 rotation_local_editor = rotation_euler_local;
+        if (ImGui::DragFloat3("Local Position", position_local_editor.ptr(), 0.1f, -inf, inf))
         {
-            SetLocalPosition(position);
+            SetLocalPosition(position_local_editor);
         }
-        if (ImGui::InputFloat3("scale", &scale[0]))
+        if (ImGui::DragFloat3("Local Rotation", rotation_local_editor.ptr(), 0.1f, 0.0f, 360.f))
         {
-            SetLocalScale(scale);
+            SetLocalRotationInEulerAngles(rotation_local_editor);
         }
-        if (ImGui::InputFloat3("rotation", &rotation[0]))
+        if (ImGui::DragFloat3("Local Scale", scale_local_editor.ptr(), 0.1f, 0.0001f, inf, "%.3f", ImGuiSliderFlags_AlwaysClamp))
         {
-            SetLocalRotation(rotation);
+            SetLocalScale(scale_local_editor);
         }
 
         ImGui::Checkbox("Debug Transforms", &debug_transforms);
         if (debug_transforms)
         {
+            math::float3 position_editor = position;
+            math::float3 rotation_editor = rotation_euler;
+            math::float3 scale_editor = scale;
+
+            ImGui::Separator();
+            if (ImGui::DragFloat3("Position", position_editor.ptr(), 0.1f, -inf, inf))
+            {
+                SetPosition(position_editor);
+            }
+            if (ImGui::DragFloat3("Rotation", rotation_editor.ptr(), 0.1f, 0.0f, 360.f))
+            {
+                SetRotationInEulerAngles(rotation_editor);
+            }
+            if (ImGui::DragFloat3("Scale", scale_editor.ptr(), 0.1f, 0.0001f, inf, "%.3f", ImGuiSliderFlags_AlwaysClamp))
+            {
+                SetScale(scale_editor);
+            }
+
             ImGui::Separator();
             ImGui::Text("Local");
             for (int r = 0; r < 4; ++r)
             {
-                auto row = local_transform.Row(r);
+                auto row = matrix_local.Row(r);
                 ImGui::Text("%.2f, %.2f, %.2f, %.2f", row[0], row[1], row[2], row[3]);
             }
 
@@ -188,9 +249,61 @@ void Hachiko::ComponentTransform::DrawGui()
             ImGui::Text("Global");
             for (int r = 0; r < 4; ++r)
             {
-                auto row = transform.Row(r);
+                auto row = matrix.Row(r);
                 ImGui::Text("%.2f, %.2f, %.2f, %.2f", row[0], row[1], row[2], row[3]);
             }
         }
+    }
+}
+
+void Hachiko::ComponentTransform::CalculateTransform(MatrixCalculationMode calculation_mode) 
+{
+    GameObject* owners_parent = game_object->parent;
+
+    switch (calculation_mode)
+    {
+        case MatrixCalculationMode::LOCAL_FROM_GLOBAL:
+        {
+            matrix = float4x4::FromTRS(position, rotation, scale);
+
+            matrix_local = owners_parent == nullptr ? matrix : owners_parent->GetTransform()->GetMatrix().Inverted() * matrix;
+
+            matrix_local.Decompose(position_local, rotation_local, scale_local);
+
+            rotation_euler_local = RadToDeg(rotation_local.ToEulerXYZ());
+        }
+        break;
+
+        case MatrixCalculationMode::GLOBAL_FROM_LOCAL:
+        {
+            matrix_local = float4x4::FromTRS(position_local, rotation_local, scale_local);
+
+            matrix = owners_parent == nullptr ? matrix_local : owners_parent->GetTransform()->GetMatrix() * matrix_local;
+
+            matrix.Decompose(position, rotation, scale);
+
+            rotation_euler = RadToDeg(rotation.ToEulerXYZ());
+        }
+        break;
+    }
+
+    right = matrix.WorldX();
+    up = matrix.WorldY();
+    front = matrix.WorldZ();
+}
+
+void Hachiko::ComponentTransform::UpdateTransformOfHierarchy(MatrixCalculationMode matrix_calculation_mode)
+{
+    CalculateTransform(matrix_calculation_mode);
+
+    changed = true;
+
+    const std::vector<GameObject*>& owner_children = game_object->children;
+
+    // As their parent transform is changed only, only updating
+    // the global transform matrix of children will suffice.
+    for (GameObject* owner_child : owner_children)
+    {
+        owner_child->GetTransform()->UpdateTransformOfHierarchy(MatrixCalculationMode::GLOBAL_FROM_LOCAL);
     }
 }

--- a/Source/src/components/ComponentTransform.h
+++ b/Source/src/components/ComponentTransform.h
@@ -7,80 +7,151 @@ namespace Hachiko
 
     class ComponentTransform : public Component
     {
+        enum class MatrixCalculationMode
+        {
+            LOCAL_FROM_GLOBAL,
+            GLOBAL_FROM_LOCAL
+        };
+
     public:
-        ComponentTransform(GameObject* new_object, float3 position = float3::zero, Quat rotation = Quat::identity, float3 scale = float3::one);
-        ComponentTransform(GameObject* new_object, const float4x4& transform = float4x4::identity);
-        ~ComponentTransform() override;
+        ComponentTransform(GameObject* container);
+        ComponentTransform(GameObject* new_object, const float3& new_position_local, const Quat& new_rotation_local, const float3& new_scale_local);
+        ComponentTransform(GameObject* new_object, const float4x4& matrix);
+        ~ComponentTransform() override = default;
 
-        static Type GetType()
-        {
-            return Type::TRANSFORM;
-        }
+        void OnTransformUpdated() override;
+        
+        static Quat SimulateLookAt(const math::float3& direction);
+        void LookAtTarget(const float3& target);
+        void LookAtDirection(const float3& direction);
 
-        void SetPosition(float3 new_position);
-        void SetRotationAxis(float3 x, float3 y, float3 z);
-        void LookAt(float3 target, float3 world_up = float3::unitY);
+        void SetGlobalTransform(const float4x4& new_matrix);
+        void SetPosition(const float3& new_position);
+        void SetScale(const float3& new_scale);
+        void SetRotationAxis(const float3& new_right, const float3& new_up, const float3& new_front);
+        void SetRotation(const Quat& new_rotation);
+        void SetRotationInEulerAngles(const float3& new_rotation_euler);
+        void SetLocalTransform(const float4x4& new_transform_local);
+        void SetLocalTransform(const float3& new_position_local, const Quat& new_rotation_local, const float3& new_scale_local);
+        void SetLocalPosition(const float3& new_position_local);
+        void SetLocalScale(const float3& new_scale_local);
+        void SetLocalRotation(const Quat& new_rotation_local);
+        void SetLocalRotationInEulerAngles(const float3& new_rotation_euler_local);
 
-        void SetLocalTransform(float4x4 new_transform);
-        void SetLocalTransform(float3 position, Quat rotation, float3 scale);
-
-        inline void SetLocalPosition(float3 new_position);
-        inline void SetLocalScale(float3 new_scale);
-        inline void SetLocalRotation(Quat new_rotation);
-        inline void SetLocalRotation(float3 rotation_angles);
-
-        void SetGlobalTransform(float4x4 transform);
-        void UpdateGlobalTransformHierarchy();
-
-        void OnTransformUpdated() override
-        {
-            changed = false;
-        }
-
-        [[nodiscard]] bool HasChanged() const
-        {
-            return changed;
-        }
-
-        [[nodiscard]] float4x4 GetTransform() const
-        {
-            return transform;
-        }
-
-        [[nodiscard]] float3 GetPosition() const
-        {
-            return transform.TranslatePart();
-        }
-
-        [[nodiscard]] float3 GetFwd() const
-        {
-            return transform.WorldZ();
-        }
-
-        [[nodiscard]] float3 GetUp() const
-        {
-            return transform.WorldY();
-        }
-
-        [[nodiscard]] float3 GetRight() const
-        {
-            return transform.WorldX();
-        }
-
+        static Type GetType();
+        [[nodiscard]] bool HasChanged() const;
+        [[nodiscard]] const float3& GetPosition() const;
+        [[nodiscard]] const float3& GetLocalPosition() const;
+        [[nodiscard]] const float3& GetScale() const;
+        [[nodiscard]] const float3& GetLocalScale() const;
+        [[nodiscard]] const Quat& GetRotation() const;
+        [[nodiscard]] const Quat& GetLocalRotation() const;
+        [[nodiscard]] const float3& GetRotationInEulerAngles() const;
+        [[nodiscard]] const float3& GetLocalRotationInEulerAngles() const;
+        [[nodiscard]] const float3& GetFront() const;
+        [[nodiscard]] const float3& GetUp() const;
+        [[nodiscard]] const float3& GetRight() const;
+        [[nodiscard]] const float4x4& GetMatrix() const;
+        [[nodiscard]] const float4x4& GetLocalMatrix() const;
+       
         void Save(JsonFormatterValue j_component) const override;
         void Load(JsonFormatterValue j_component) override;
 
         void DrawGui() override;
 
     private:
-        bool changed = true;
+        void CalculateTransform(MatrixCalculationMode calculation_mode);
+        void UpdateTransformOfHierarchy(MatrixCalculationMode matrix_calculation_mode);
 
-        float4x4 transform;
-
-        float4x4 local_transform;
-        float3 local_position;
-        float3 local_scale;
-        Quat local_rotation;
-        float3 local_rotation_euler;
+    private:
+        bool        changed = true;
+        float4x4    matrix;
+        float4x4    matrix_local;
+        float3      position;
+        float3      position_local;
+        float3      scale;
+        float3      scale_local;
+        Quat        rotation;
+        Quat        rotation_local;
+        float3      rotation_euler;
+        float3      rotation_euler_local;
+        float3      right;
+        float3      up;
+        float3      front;
     };
+}
+
+inline Hachiko::Component::Type Hachiko::ComponentTransform::GetType()
+{
+    return Type::TRANSFORM;
+}
+
+inline bool Hachiko::ComponentTransform::HasChanged() const
+{
+    return changed;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetPosition() const
+{
+    return position;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetLocalPosition() const
+{
+    return position_local;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetScale() const
+{
+    return scale;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetLocalScale() const
+{
+    return scale_local;
+}
+
+inline const Quat& Hachiko::ComponentTransform::GetRotation() const
+{
+    return rotation;
+}
+
+inline const Quat& Hachiko::ComponentTransform::GetLocalRotation() const
+{
+    return rotation_local;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetRotationInEulerAngles() const
+{
+    return rotation_euler;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetLocalRotationInEulerAngles() const
+{
+    return rotation_euler_local;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetFront() const
+{
+    return front;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetUp() const
+{
+    return up;
+}
+
+inline const float3& Hachiko::ComponentTransform::GetRight() const
+{
+    return right;
+}
+
+inline const float4x4& Hachiko::ComponentTransform::GetMatrix() const
+{
+    return matrix;
+}
+
+inline const float4x4& Hachiko::ComponentTransform::GetLocalMatrix() const
+{
+    return matrix_local;
 }

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -242,7 +242,7 @@ void Hachiko::GameObject::UpdateBoundingBoxes()
     if (mesh != nullptr)
     {
         obb = mesh->GetAABB();
-        obb.Transform(transform->GetTransform());
+        obb.Transform(transform->GetMatrix());
         // Enclose is accumulative, reset the box
         aabb.SetNegativeInfinity();
         aabb.Enclose(obb);

--- a/Source/src/core/GameObject.h
+++ b/Source/src/core/GameObject.h
@@ -77,6 +77,11 @@ namespace Hachiko
             return components;
         }
 
+        [[nodiscard]] ComponentTransform* GetTransform() const 
+        {
+            return transform;
+        }
+
         template<typename RetComponent>
         RetComponent* GetComponent()
         {

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -122,7 +122,7 @@ Hachiko::GameObject* Hachiko::Scene::RayCast(const LineSegment& segment) const
         {
             // Transform ray to mesh space, more efficient
             LineSegment local_segment(segment);
-            local_segment.Transform(game_object->GetComponent<ComponentTransform>()->GetTransform().Inverted());
+            local_segment.Transform(game_object->GetTransform()->GetMatrix().Inverted());
 
             const float* vertices = mesh->GetVertices();
             const unsigned* indices = mesh->GetIndices();
@@ -152,17 +152,17 @@ Hachiko::GameObject* Hachiko::Scene::RayCast(const LineSegment& segment) const
 void Hachiko::Scene::CreateLights()
 {
     GameObject* sun = CreateNewGameObject("Sun", root);
-    sun->GetComponent<ComponentTransform>()->SetLocalPosition(float3(1, 1, -1));
-    sun->GetComponent<ComponentTransform>()->LookAt(float3(0, 0, 0));
+    sun->GetTransform()->SetLocalPosition(float3(1, 1, -1));
+    sun->GetTransform()->LookAtTarget(float3(0, 0, 0));
     sun->CreateComponent(Component::Type::DIRLIGHT);
 
     GameObject* spot = CreateNewGameObject("Spot Light", root);
-    spot->GetComponent<ComponentTransform>()->SetLocalPosition(float3(-1, 1, -1));
+    spot->GetTransform()->SetLocalPosition(float3(-1, 1, -1));
 
     spot->CreateComponent(Component::Type::SPOTLIGHT);
 
     GameObject* point = CreateNewGameObject("Point Light", root);
-    point->GetComponent<ComponentTransform>()->SetLocalPosition(float3(0, 1, -1));
+    point->GetTransform()->SetLocalPosition(float3(0, 1, -1));
     point->CreateComponent(Component::Type::POINTLIGHT);
 }
 
@@ -180,7 +180,7 @@ void Hachiko::Scene::LoadNode(const aiScene* scene, const aiNode* node, GameObje
         aiVector3D aiTranslation, aiScale;
         aiQuaternion aiRotation;
         node->mTransformation.Decompose(aiScale, aiRotation, aiTranslation);
-        model_part->GetComponent<ComponentTransform>()->SetLocalTransform(float3(aiTranslation.x, aiTranslation.y, aiTranslation.z),
+        model_part->GetTransform()->SetLocalTransform(float3(aiTranslation.x, aiTranslation.y, aiTranslation.z),
                                                                           Quat(aiRotation.x, aiRotation.y, aiRotation.z, aiRotation.w),
                                                                           float3(aiScale.x, aiScale.y, aiScale.z));
     }
@@ -195,9 +195,9 @@ void Hachiko::Scene::LoadNode(const aiScene* scene, const aiNode* node, GameObje
 Hachiko::GameObject* Hachiko::Scene::CreateDebugCamera()
 {
     GameObject* camera = CreateNewGameObject("Debug Camera", root);
-    camera->GetComponent<ComponentTransform>()->SetLocalPosition(float3(5, 5, 0));
+    camera->GetTransform()->SetLocalPosition(float3(5, 5, 0));
     camera->CreateComponent(Component::Type::CAMERA);
-    camera->GetComponent<ComponentTransform>()->LookAt(float3(0, 5, 0));
+    camera->GetTransform()->LookAtTarget(float3(0, 5, 0));
 
     auto* debug_camera = camera->GetComponent<ComponentCamera>();
     debug_camera->SetFarPlane(100.0f);

--- a/Source/src/ui/WindowScene.cpp
+++ b/Source/src/ui/WindowScene.cpp
@@ -173,7 +173,7 @@ void Hachiko::WindowScene::DrawScene()
         // Using GL format which means transposing them
         view = camera->GetViewMatrix(transposed);
         float4x4 projection = camera->GetProjectionMatrix(transposed);
-        float4x4 model = selected_object->GetComponent<ComponentTransform>()->GetTransform().Transposed();
+        float4x4 model = selected_object->GetTransform()->GetMatrix().Transposed();
         float4x4 delta;
 
         ImGuizmo::SetRect(guizmo_rect_origin.x, guizmo_rect_origin.y, texture_size.x, texture_size.y);
@@ -186,7 +186,7 @@ void Hachiko::WindowScene::DrawScene()
         {
             // Transpose back again to store in our format
             model.Transpose();
-            selected_object->GetComponent<ComponentTransform>()->SetGlobalTransform(model);
+            selected_object->GetTransform()->SetGlobalTransform(model);
         }
     }
 }


### PR DESCRIPTION
This pull request mainly improves existing ComponentTransform using the one Strawhat Engine uses. 
Changes are as follows:
- Support for both global and local changes.
- Cleaned up the whole api.
- Changed unnecessary .GetComponent<ComponentTransform> calls into .GetTransform() which returns cached transform variable inside GameObject.
- Improved transform component inspector ui with draggable input fields and added ability to set global transforms via additional draggable input fields when debug checkbox is checked.