### PR TITLE
Resizing on gizmos rotates the object

### DIFF
--- a/Source/src/ui/ImGuiUtils.h
+++ b/Source/src/ui/ImGuiUtils.h
@@ -21,7 +21,7 @@ namespace Hachiko
 
         bool CollapsingHeader(GameObject* game_object, Component* component, const char* header_name);
 
-        bool ToolbarButton(ImFont* const font, const char* font_icon, bool active, const char* tooltip_desc);
+        bool ToolbarButton(ImFont* const font, const char* font_icon, bool active, const char* tooltip_desc, const bool enabled = true);
 
         static void DisplayTooltip(const char* desc);
 

--- a/Source/src/ui/ImguiUtils.cpp
+++ b/Source/src/ui/ImguiUtils.cpp
@@ -86,13 +86,18 @@ bool Hachiko::ImGuiUtils::CollapsingHeader(GameObject* game_object, Component* c
     return open;
 }
 
-bool Hachiko::ImGuiUtils::ToolbarButton(ImFont* const font, const char* font_icon, bool active, const char* tooltip_desc)
+bool Hachiko::ImGuiUtils::ToolbarButton(ImFont* const font, const char* font_icon, bool active, const char* tooltip_desc, const bool enabled)
 {
     const ImVec4 col_active = ImGui::GetStyle().Colors[ImGuiCol_ButtonActive];
-    const ImVec4 bg_color = active ? col_active : ImGui::GetStyle().Colors[ImGuiCol_Text];
-
+    ImVec4 bg_color = active ? col_active : ImGui::GetStyle().Colors[ImGuiCol_Text];
     ImGui::SameLine();
     const auto frame_padding = ImGui::GetStyle().FramePadding;
+
+    if (!enabled)
+    {
+        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+        bg_color.w = 0.5f;
+    }
     ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0, 0, 0, 0));
     ImGui::PushStyleColor(ImGuiCol_Text, bg_color);
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
@@ -103,13 +108,19 @@ bool Hachiko::ImGuiUtils::ToolbarButton(ImFont* const font, const char* font_ico
 
     ImGui::PushFont(font);
     active = ImGui::Button(font_icon);
-
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1, 1, 1, 1));
-    ImGui::SameLine(); DisplayTooltip(tooltip_desc);
-
     ImGui::PopFont();
-    ImGui::PopStyleColor(5);
+    ImGui::PopStyleColor(4);
     ImGui::PopStyleVar(3);
+
+    if (!enabled)
+    {
+        ImGui::PopItemFlag();
+    }
+    else
+    {
+        ImGui::SameLine();
+        DisplayTooltip(tooltip_desc);
+    }
 
     return active;
 }

--- a/Source/src/ui/ImguiUtils.cpp
+++ b/Source/src/ui/ImguiUtils.cpp
@@ -92,7 +92,7 @@ bool Hachiko::ImGuiUtils::ToolbarButton(ImFont* const font, const char* font_ico
     ImVec4 bg_color = active ? col_active : ImGui::GetStyle().Colors[ImGuiCol_Text];
     ImGui::SameLine();
     const auto frame_padding = ImGui::GetStyle().FramePadding;
-
+    // If the button is not enabled we lower its alpha channel and disable the widget
     if (!enabled)
     {
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);

--- a/Source/src/ui/WindowScene.cpp
+++ b/Source/src/ui/WindowScene.cpp
@@ -66,12 +66,12 @@ void Hachiko::WindowScene::GuizmoOptionsController()
     ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
     ImGui::SameLine();
 
-    if (ImGuiUtils::ToolbarButton(App->editor->m_big_icon_font, ICON_FA_HOME, guizmo_mode == ImGuizmo::LOCAL, "Switches to Local Gizmos mode."))
+    if (ImGuiUtils::ToolbarButton(App->editor->m_big_icon_font, ICON_FA_HOME, guizmo_mode == ImGuizmo::LOCAL, "Switches to Local Gizmos mode.", guizmo_operation != ImGuizmo::SCALE))
     {
         guizmo_mode = ImGuizmo::LOCAL;
     }
     
-    if (ImGuiUtils::ToolbarButton(App->editor->m_big_icon_font, ICON_FA_GLOBE, guizmo_mode == ImGuizmo::WORLD, "Switches to Global Gizmos mode."))
+    if (ImGuiUtils::ToolbarButton(App->editor->m_big_icon_font, ICON_FA_GLOBE, guizmo_mode == ImGuizmo::WORLD, "Switches to Global Gizmos mode.", guizmo_operation != ImGuizmo::SCALE))
     {
         guizmo_mode = ImGuizmo::WORLD;
     }
@@ -182,7 +182,9 @@ void Hachiko::WindowScene::DrawScene()
         ImGuizmo::SetRect(guizmo_rect_origin.x, guizmo_rect_origin.y, texture_size.x, texture_size.y);
         ImGuizmo::SetDrawlist();
 
-        Manipulate(view.ptr(), projection.ptr(), guizmo_operation, guizmo_mode, model.ptr(), delta.ptr());
+        // Scale will always be on local regarding on ImGuizmo MODE, check is done here to keep user's selected MODE
+        const bool is_scaling = guizmo_operation == ImGuizmo::SCALE;
+        Manipulate(view.ptr(), projection.ptr(), guizmo_operation, is_scaling ? ImGuizmo::LOCAL : guizmo_mode, model.ptr(), delta.ptr());
 
         using_guizmo = ImGuizmo::IsUsing();
         if (using_guizmo && !delta.IsIdentity())


### PR DESCRIPTION
#8 Bug fixed, objects should **never** rotate on scale. Some visual enhancements.
- Now when resizing it **always** works on objects local space.
- Toolbar guizmo MODE buttons deactivated if **resize** is selected.
- Added an optional parameter to ToolbarButton() to set if enabled. Default at true.
- Toolbar labels text color adjusted to syncronize with theme.
