### PR TITLE
Now the compiler only shows warnings for the codes we wrote in our project.

### DIFF
--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -77,6 +77,7 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)bin\build\$(Platform)\$(Configuration)\</IntDir>
+    <ExternalIncludePath>$(ProjectDir)vendors;$(VC_IncludePath);$(WindowsSDK_IncludePath);</ExternalIncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -85,6 +86,7 @@
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)bin\build\$(Platform)\$(Configuration)\</IntDir>
+    <ExternalIncludePath>$(ProjectDir)vendors;$(VC_IncludePath);$(WindowsSDK_IncludePath);</ExternalIncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -110,6 +112,10 @@
       <PrecompiledHeaderFile>core/hepch.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>
       </ForcedIncludeFiles>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ExternalTemplatesDiagnostics>false</ExternalTemplatesDiagnostics>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -148,6 +154,10 @@
       <PrecompiledHeaderFile>core/hepch.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>
       </ForcedIncludeFiles>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ExternalTemplatesDiagnostics>false</ExternalTemplatesDiagnostics>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/src/Globals.h
+++ b/Source/src/Globals.h
@@ -4,9 +4,9 @@
 
 #define HE_LOG(format, ...) Logging->log(__FILENAME__, __LINE__, format, __VA_ARGS__);
 
-#define M_PI 3.14159265358979323846
-constexpr float TO_RAD = static_cast<float>(M_PI) / 180.0f;
-constexpr float TO_DEG = 180.0f / static_cast<float>(M_PI);
+#define HACHIKO_PI 3.14159265358979323846
+constexpr float TO_RAD = static_cast<float>(HACHIKO_PI) / 180.0f;
+constexpr float TO_DEG = 180.0f / static_cast<float>(HACHIKO_PI);
 
 enum class UpdateStatus
 {

--- a/Source/src/Quadtree.cpp
+++ b/Source/src/Quadtree.cpp
@@ -1,6 +1,6 @@
 #include "core/hepch.h"
 #include "Quadtree.h"
-#include "debugdraw.h"
+#include <debugdraw.h>
 
 Hachiko::QuadtreeNode::QuadtreeNode(const AABB& box, QuadtreeNode* parent) :
     box(box),

--- a/Source/src/Quadtree.h
+++ b/Source/src/Quadtree.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "MathGeoLib.h"
-
 #include "core/GameObject.h"
 
+#include <MathGeoLib.h>
 #include <list>
 
 #define QUADTREE_MAX_ITEMS 8

--- a/Source/src/RenderList.h
+++ b/Source/src/RenderList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MathGeoLib.h"
+#include <MathGeoLib.h>
 
 #include <vector>
 

--- a/Source/src/components/ComponentCamera.h
+++ b/Source/src/components/ComponentCamera.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Component.h"
-#include "MathGeoLib.h"
+#include <MathGeoLib.h>
 
 #define DEFAULT_CAMERA_WIDTH 1920
 #define DEFAULT_CAMERA_HEIGHT 1080

--- a/Source/src/components/ComponentMaterial.h
+++ b/Source/src/components/ComponentMaterial.h
@@ -3,7 +3,7 @@
 #include "Component.h"
 #include "resources/ResourceMaterial.h"
 
-#include "assimp/scene.h"
+#include <assimp/scene.h>
 
 namespace Hachiko
 {

--- a/Source/src/components/ComponentMesh.h
+++ b/Source/src/components/ComponentMesh.h
@@ -3,8 +3,8 @@
 
 #include "resources/ResourceMesh.h"
 
-#include "assimp/scene.h"
-#include "MathGeoLib.h"
+#include <assimp/scene.h>
+#include <MathGeoLib.h>
 
 namespace Hachiko
 {

--- a/Source/src/core/GameObject.h
+++ b/Source/src/core/GameObject.h
@@ -1,7 +1,8 @@
 #pragma once
-#include "MathGeoLib.h"
 
+#include <MathGeoLib.h>
 #include <vector>
+
 #include "utils/UUID.h"
 #include "components/Component.h"
 

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -11,9 +11,9 @@
 #include "modules/ModuleCamera.h"
 #include "modules/ModuleDebugDraw.h"
 
-#include "assimp/cimport.h"
-#include "assimp/postprocess.h"
-#include "assimp/Importer.hpp"
+#include <assimp/cimport.h>
+#include <assimp/postprocess.h>
+#include <assimp/Importer.hpp>
 
 Hachiko::Scene::Scene():
     root(new GameObject(nullptr, float4x4::identity, "Root")),

--- a/Source/src/core/Scene.h
+++ b/Source/src/core/Scene.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "assimp/scene.h"
-
+#include <assimp/scene.h>
 #include <string>
 #include <vector>
 

--- a/Source/src/core/serialization/TypeConverter.h
+++ b/Source/src/core/serialization/TypeConverter.h
@@ -1,12 +1,12 @@
 #pragma once
-#include "yaml-cpp/yaml.h"
+
+#include <yaml-cpp/yaml.h>
 #include <Math/float2.h>
 #include <Math/float3.h>
 #include <Math/float4.h>
 #include <Math/Quat.h>
 #include <Math/float4x4.h>
-
-#include "assimp/vector3.h"
+#include <assimp/vector3.h>
 
 namespace YAML
 {

--- a/Source/src/importers/MaterialImporter.h
+++ b/Source/src/importers/MaterialImporter.h
@@ -2,7 +2,7 @@
 
 #include "utils/JsonFormatterValue.h"
 
-#include "assimp/scene.h"
+#include <assimp/scene.h>
 
 namespace Hachiko
 {

--- a/Source/src/importers/MeshImporter.h
+++ b/Source/src/importers/MeshImporter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "utils/UUID.h"
-#include "assimp/scene.h"
+#include <assimp/scene.h>
 
 namespace Hachiko
 {

--- a/Source/src/modules/ModuleHardware.h
+++ b/Source/src/modules/ModuleHardware.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Module.h"
-#include "SDL.h"
+#include <SDL.h>
 
 namespace Hachiko
 {

--- a/Source/src/modules/ModuleInput.h
+++ b/Source/src/modules/ModuleInput.h
@@ -2,7 +2,7 @@
 #include "Module.h"
 #include "Globals.h"
 
-#include "SDL.h"
+#include <SDL.h>
 
 namespace Hachiko
 {

--- a/Source/src/modules/ModuleTexture.h
+++ b/Source/src/modules/ModuleTexture.h
@@ -1,8 +1,7 @@
 #pragma once
 #include "Module.h"
 
-#include "il.h"
-
+#include <il.h>
 #include <string>
 
 namespace Hachiko

--- a/Source/src/modules/ModuleWindow.h
+++ b/Source/src/modules/ModuleWindow.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Module.h"
-#include "SDL.h"
+#include <SDL.h>
 
 namespace Hachiko
 {

--- a/Source/src/resources/ResourceMesh.h
+++ b/Source/src/resources/ResourceMesh.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Resource.h"
 
-#include "MathGeoLib.h"
+#include <MathGeoLib.h>
 
 namespace Hachiko
 {

--- a/Source/src/ui/ImGuiUtils.h
+++ b/Source/src/ui/ImGuiUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "imgui.h"
+#include <imgui.h>
 
 namespace Hachiko
 {

--- a/Source/src/ui/ImguiUtils.cpp
+++ b/Source/src/ui/ImguiUtils.cpp
@@ -2,7 +2,7 @@
 #include "ImGuiUtils.h"
 #include <IconsFontAwesome5.h>
 
-#include "imgui_internal.h"
+#include <imgui_internal.h>
 
 #include "core/GameObject.h"
 #include "components/Component.h"

--- a/Source/src/utils/JsonFormatterValue.h
+++ b/Source/src/utils/JsonFormatterValue.h
@@ -2,8 +2,7 @@
 
 //TODO Improve using this https://github.com/systelab/cpp-rapidjson-json-adapter/blob/master/src/RapidJSONAdapter/JSONValue.h
 
-#include "rapidjson/document.h"
-
+#include <rapidjson/document.h>
 #include <string>
 
 namespace Hachiko

--- a/Source/vendors/ImGuiFileDialog-0.6.3/ImGuiFileDialog.cpp
+++ b/Source/vendors/ImGuiFileDialog-0.6.3/ImGuiFileDialog.cpp
@@ -25,7 +25,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "ImGuiFileDialog.h"
+#pragma warning(push, 0)
+
+#include <ImGuiFileDialog.h>
 
 #ifdef __cplusplus
 
@@ -55,7 +57,7 @@ SOFTWARE.
 	#ifdef USE_STD_FILESYSTEM
 		#include <Windows.h>
 	#else
-		#include "dirent/dirent.h" // directly open the dirent file attached to this lib
+		#include <dirent/dirent.h> // directly open the dirent file attached to this lib
 	#endif // USE_STD_FILESYSTEM
 	#define PATH_SEP '\\'
 	#ifndef PATH_MAX
@@ -5051,3 +5053,5 @@ IMGUIFILEDIALOG_API void ManageGPUThumbnails(ImGuiFileDialog* vContext)
 	}
 }
 #endif // USE_THUMBNAILS
+
+#pragma warning(pop)


### PR DESCRIPTION
As there are a lot of warnings that we don't have the control over (external libraries and stuff),  Wherever we include an external file, I set the warning level of external headers to 0 locally. Now we will only gonna see the warnings that are coming from our code (there may be some from included source codes). These both warnings are from W3 which is the default one. Of course, if you set the dropdown of showq warnings from Build only to Build + Intellisense, the warnings will increase, but that's because Intellisense analyzes all the files that are added to the project