### PR TITLE
Fixed view menu

### DIFF
--- a/Source/src/modules/ModuleEditor.cpp
+++ b/Source/src/modules/ModuleEditor.cpp
@@ -302,18 +302,18 @@ void Hachiko::ModuleEditor::FileMenu() const
     }
 }
 
-void Hachiko::ModuleEditor::ViewMenu() const
+void Hachiko::ModuleEditor::ViewMenu()
 {
     if (ImGui::BeginMenu("View"))
     {
-        ImGui::MenuItem(w_scene.name, "", &w_scene.active);
-        ImGui::MenuItem(w_inspector.name, "", &w_inspector.active);
-        ImGui::MenuItem(w_hierarchy.name, "", &w_hierarchy.active);
-        ImGui::MenuItem(w_configuration.name, "", &w_configuration.active);
-        ImGui::MenuItem(w_about.name, "", &w_about.active);
-        ImGui::MenuItem(w_resource.name, "", &w_resource.active);
-        ImGui::MenuItem(w_project.name, "", &w_project.active);
-        ImGui::MenuItem(w_timers.name, "", &w_timers.active);
+        ImGui::MenuItem(w_scene.name, nullptr, &w_scene.active);
+        ImGui::MenuItem(w_inspector.name, nullptr, &w_inspector.active);
+        ImGui::MenuItem(w_hierarchy.name, nullptr, &w_hierarchy.active);
+        ImGui::MenuItem(w_configuration.name, nullptr, &w_configuration.active);
+        ImGui::MenuItem(w_about.name, nullptr, &w_about.active);
+        ImGui::MenuItem(w_resource.name, nullptr, &w_resource.active);
+        ImGui::MenuItem(w_project.name, nullptr, &w_project.active);
+        ImGui::MenuItem(w_timers.name, nullptr, &w_timers.active);
         ImGui::EndMenu();
     }
 }

--- a/Source/src/modules/ModuleEditor.h
+++ b/Source/src/modules/ModuleEditor.h
@@ -93,7 +93,7 @@ namespace Hachiko
         void FileMenu() const;
         void EditMenu() const;
         void GoMenu() const;
-        void ViewMenu() const;
+        void ViewMenu();
         void ThemeMenu() const;
 
         GameObject* selected_go = nullptr;


### PR DESCRIPTION
There are very similar menu items functions in terms of parameter list
```c++
bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, bool enabled)
{
    return MenuItemEx(label, NULL, shortcut, selected, enabled);
}

bool ImGui::MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled)
{
    if (MenuItemEx(label, NULL, shortcut, p_selected ? *p_selected : false, enabled))
    {
        if (p_selected)
            *p_selected = !*p_selected;
        return true;
    }
    return false;
}
```

Turns out that the first one was being called now when it didnt do so in the past (in AltarBoy), I'm guessing due to changing c++ version? I don't know otherwise.

UPDATE: Probably the issue was caused by the method being declared as const because windows were class members, this caused the wrong imgui call to be used