### PR TITLE
Fixing unintentional clicking on hierarchy window when another window is on top of it

### DIFF
--- a/Source/src/ui/WindowHierarchy.cpp
+++ b/Source/src/ui/WindowHierarchy.cpp
@@ -70,7 +70,7 @@ void Hachiko::WindowHierarchy::DrawGameObject(GameObject* game_object)
 
     const bool node_open = ImGui::TreeNodeEx(game_object, flags, game_object->name.c_str());
 
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_RectOnly) && !ImGui::IsItemToggledOpen())
+    if (ImGui::IsItemHovered() && !ImGui::IsItemToggledOpen())
     {
         if (dragged_object && dragged_object != game_object)
         {

--- a/Source/src/ui/WindowHierarchy.cpp
+++ b/Source/src/ui/WindowHierarchy.cpp
@@ -45,6 +45,7 @@ void Hachiko::WindowHierarchy::DrawChildren(const GameObject* game_object)
     }
 }
 
+// TODO: Refactor to simplify function
 void Hachiko::WindowHierarchy::DrawGameObject(GameObject* game_object)
 {
     ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen;


### PR DESCRIPTION
Removing flag that activates all other flags in IsItemHovered that made the items in the hierarchy window be selected while using other windows/popups that were physically on top of them, creating sometimes engine braking bugs due to loading of scene and picking of unexisting GO at the same time. 