### PR TITLE
Teleport character to locations

### DIFF
--- a/Source/src/modules/ModuleDebugMode.cpp
+++ b/Source/src/modules/ModuleDebugMode.cpp
@@ -22,11 +22,10 @@ bool Hachiko::ModuleDebugMode::Init()
 	player = FindPlayer();
 
 	// God mode
-    playerLocations.resize(4);
-    playerLocations[0] = float3(0.0f, 0.0f, 0.0f);
-    playerLocations[1] = float3(10.0f, 0.0f, 0.0f);
-    playerLocations[2] = float3(10.0f, 0.0f, 7.0f);
-    playerLocations[3] = float3(7.0f, 0.0f, 7.0f);
+    playerLocations.push_back(float3(0.0f, 0.0f, 0.0f));
+    playerLocations.push_back(float3(10.0f, 0.0f, 0.0f));
+    playerLocations.push_back(float3(10.0f, 0.0f, 7.0f));
+    playerLocations.push_back(float3(7.0f, 0.0f, 7.0f));
 	
 	SetupWindow();
 
@@ -69,7 +68,7 @@ UpdateStatus Hachiko::ModuleDebugMode::Update(const float delta)
         }
 	}
 
-	// Teleport player to the nearest position from playerLocations
+	// Teleport player to the nearest position in playerLocations
 	if (App->input->GetKey(SDL_SCANCODE_SPACE) == Hachiko::KeyState::KEY_DOWN)
 	{
         player = FindPlayer();
@@ -88,7 +87,7 @@ UpdateStatus Hachiko::ModuleDebugMode::Update(const float delta)
         player->GetTransform()->SetGlobalPosition(playerLocations[loc]);
 	}
 	
-	// Teleport player to the next position from playerLocations
+	// Teleport player to the next position in playerLocations
     if (App->input->GetKey(SDL_SCANCODE_RETURN) == Hachiko::KeyState::KEY_DOWN)
 	{
         player = FindPlayer();

--- a/Source/src/modules/ModuleDebugMode.cpp
+++ b/Source/src/modules/ModuleDebugMode.cpp
@@ -58,11 +58,10 @@ UpdateStatus Hachiko::ModuleDebugMode::Update(const float delta)
 	// Teleport player with mouse double click
 	if (App->input->GetKey(SDL_SCANCODE_RALT) == Hachiko::KeyState::KEY_REPEAT && ImGui::IsMouseDoubleClicked(0))
 	{
-        Plane plane = Plane(vec(50, 0, 50), vec(50, 0, -50), vec(-50, 0, -50));
+        Plane plane(vec(50, 0, 50), vec(50, 0, -50), vec(-50, 0, -50));
         float d = 0;
         if (line.Intersects(plane, &d))
         {
-            vec v = line.GetPoint(d);
             player = FindPlayer();
             player->GetTransform()->SetGlobalPosition(line.GetPoint(d));
         }
@@ -74,7 +73,7 @@ UpdateStatus Hachiko::ModuleDebugMode::Update(const float delta)
         player = FindPlayer();
         float3 currentPosition = player->GetTransform()->GetGlobalPosition();
 		
-		int dist = 1000.0f;
+		float dist = 1000.0f;
 		int loc = 0;
 		for (int i = 0; i < playerLocations.size(); ++i)
 		{

--- a/Source/src/modules/ModuleDebugMode.cpp
+++ b/Source/src/modules/ModuleDebugMode.cpp
@@ -3,6 +3,9 @@
 #include "ModuleDebugMode.h"
 #include "core/GameObject.h"
 
+#include "ModuleCamera.h"
+#include "components/ComponentCamera.h"
+
 bool Hachiko::ModuleDebugMode::Init()
 {
 	
@@ -17,6 +20,13 @@ bool Hachiko::ModuleDebugMode::Init()
 
 	// Deprecated after VS1
 	player = FindPlayer();
+
+	// God mode
+    playerLocations.resize(4);
+    playerLocations[0] = float3(0.0f, 0.0f, 0.0f);
+    playerLocations[1] = float3(10.0f, 0.0f, 0.0f);
+    playerLocations[2] = float3(10.0f, 0.0f, 7.0f);
+    playerLocations[3] = float3(7.0f, 0.0f, 7.0f);
 	
 	SetupWindow();
 
@@ -42,6 +52,65 @@ UpdateStatus Hachiko::ModuleDebugMode::Update(const float delta)
 	}
 
 	RenderGui();
+
+
+	// God mode
+	
+	// Teleport player with mouse double click
+	if (App->input->GetKey(SDL_SCANCODE_RALT) == Hachiko::KeyState::KEY_REPEAT && ImGui::IsMouseDoubleClicked(0))
+	{
+        Plane plane = Plane(vec(50, 0, 50), vec(50, 0, -50), vec(-50, 0, -50));
+        float d = 0;
+        if (line.Intersects(plane, &d))
+        {
+            vec v = line.GetPoint(d);
+            player = FindPlayer();
+            player->GetTransform()->SetGlobalPosition(line.GetPoint(d));
+        }
+	}
+
+	// Teleport player to the nearest position from playerLocations
+	if (App->input->GetKey(SDL_SCANCODE_SPACE) == Hachiko::KeyState::KEY_DOWN)
+	{
+        player = FindPlayer();
+        float3 currentPosition = player->GetTransform()->GetGlobalPosition();
+		
+		int dist = 1000.0f;
+		int loc = 0;
+		for (int i = 0; i < playerLocations.size(); ++i)
+		{
+            if (dist > math::Distance(currentPosition, playerLocations[i]) && math::Distance(currentPosition, playerLocations[i]) != 0)
+			{
+                dist = math::Distance(currentPosition, playerLocations[i]);
+                loc = i;
+			}
+		}
+        player->GetTransform()->SetGlobalPosition(playerLocations[loc]);
+	}
+	
+	// Teleport player to the next position from playerLocations
+    if (App->input->GetKey(SDL_SCANCODE_RETURN) == Hachiko::KeyState::KEY_DOWN)
+	{
+        player = FindPlayer();
+        float3 currentPosition = player->GetTransform()->GetGlobalPosition();
+        
+		int loc = 0;
+		for (int i = 0; i < playerLocations.size(); ++i)
+		{
+            if (math::Distance(currentPosition, playerLocations[i]) == 0)
+			{
+                loc = i + 1;
+                break;
+			}
+		}
+
+		if (loc == playerLocations.size())
+		{
+            loc = 0;
+		}
+
+        player->GetTransform()->SetGlobalPosition(playerLocations[loc]);
+	}
 
 	return UpdateStatus::UPDATE_CONTINUE;
 }
@@ -93,6 +162,12 @@ const Hachiko::GameObject* Hachiko::ModuleDebugMode::FindPlayer() const
 	return nullptr;
 }
 
+// God mode
+void Hachiko::ModuleDebugMode::SetLine(LineSegment newLine) 
+{
+    line = newLine;
+}
+
 void Hachiko::ModuleDebugMode::DrawGUI()
 {
 	static const float vram_total = (float)hw_info.vram_capacity / 1024.0f;
@@ -141,7 +216,6 @@ void Hachiko::ModuleDebugMode::DrawGUI()
 				player->GetTransform()->SetGlobalPosition(player_pos_editor);
 			}
 		}
-		
 	}
 	ImGui::End();
 }

--- a/Source/src/modules/ModuleDebugMode.h
+++ b/Source/src/modules/ModuleDebugMode.h
@@ -44,6 +44,9 @@ namespace Hachiko
 		[[nodiscard]] bool IsActive() const { return is_gui_active; }
 		void Toggle() { is_gui_active = !is_gui_active; }
 
+		// God mode
+		void SetLine(LineSegment newLine);
+
 	private:
 		void DrawGUI();
 		ImGuiWindowFlags SetupWindow();
@@ -63,6 +66,10 @@ namespace Hachiko
 		ImGuiWindowFlags window_flags;
 		//Deprecated after VS1
 		const GameObject* player;
+
+		// God mode
+        LineSegment line;
+        std::vector<float3> playerLocations;
 	};
 }
 

--- a/Source/src/ui/WindowScene.cpp
+++ b/Source/src/ui/WindowScene.cpp
@@ -6,6 +6,7 @@
 #include "modules/ModuleCamera.h"
 #include "modules/ModuleRender.h"
 #include "modules/ModuleSceneManager.h"
+#include "modules/ModuleDebugMode.h"
 
 #include "components/ComponentCamera.h"
 #include "components/ComponentTransform.h"
@@ -208,6 +209,7 @@ Hachiko::GameObject* Hachiko::WindowScene::SelectObject(ComponentCamera* camera,
     const float y_normalized = -(mouse_viewport_pos.y / texture_size.y * 2.f - 1.f);
 
     const LineSegment line = camera->RayCast(x_normalized, y_normalized);
+    App->debug_mode->SetLine(line);
     GameObject* selected = scene->RayCast(line);
 
     return selected;


### PR DESCRIPTION
"Right Alt" + double click to teleport the player to a certain position (X,Z) on the plane where Y = 0.

"Space" to jump to the nearest position in the vector of player's possible locations.

"Return" to jump to the next position in the vector of player's possible locations or the first one if the current position is not one of the positions in the vector.