### PR TITLE
Bugfix dont save scene on play mode

### DIFF
--- a/Source/src/core/preferences/src/EditorPreferences.cpp
+++ b/Source/src/core/preferences/src/EditorPreferences.cpp
@@ -49,6 +49,11 @@ void EditorPreferences::LoadConfigurationData(const YAML::Node& node)
         {
             vsync = it->second.as<int>();
         }
+
+        if (it->first.as<std::string>()._Equal(SCENE_AUTOSAVE))
+        {
+            scene_autosave = it->second.as<bool>();
+        }
     }
 }
 
@@ -60,4 +65,5 @@ void EditorPreferences::SaveConfigurationData(YAML::Node& node)
     node[group_name][THEME] = Editor::Theme::ToString(theme);
     node[group_name][VSYNC] = vsync;
     node[group_name][SCENE_BACKGROUND_COLOR] = scene_background_color;
+    node[group_name][SCENE_AUTOSAVE] = scene_autosave;
 }

--- a/Source/src/core/preferences/src/EditorPreferences.h
+++ b/Source/src/core/preferences/src/EditorPreferences.h
@@ -91,6 +91,16 @@ namespace Hachiko
             return theme;
         }
 
+        void SetAutosave(bool value)
+        {
+            scene_autosave = value;
+        }
+
+        [[nodiscard]] bool GetAutosave()
+        {
+            return scene_autosave;
+        }
+
     private:
         bool display_debug_draw = false;
         float3 scene_background_color = float3(0.9f);
@@ -100,6 +110,7 @@ namespace Hachiko
 
         float max_fps = 250.0f;
         bool fullscreen = false;
+        bool scene_autosave = false;
         int vsync = 0;
         float fps_threshold = 1000.0f / max_fps;
         Editor::Theme::Type theme = Editor::Theme::Type::DARK;

--- a/Source/src/core/preferences/src/ResourcesPreferences.cpp
+++ b/Source/src/core/preferences/src/ResourcesPreferences.cpp
@@ -72,6 +72,12 @@ void ResourcesPreferences::LoadConfigurationData(const YAML::Node& node)
         }
 
         // Library path
+        if (it->first.as<std::string>()._Equal(SCENES_LIBRARY))
+        {
+            scenes_library = std::move(it->second.as<std::string>());
+            continue;
+        }
+
         if (it->first.as<std::string>()._Equal(MODELS_LIBRARY))
         {
             models_library = std::move(it->second.as<std::string>());
@@ -125,6 +131,7 @@ void ResourcesPreferences::SaveConfigurationData(YAML::Node& node)
     node[group_name][ANIMATIONS_ASSETS] = animations_assets;
     node[group_name][SKYBOX_ASSETS] = skybox_assets;
 
+    node[group_name][SCENES_LIBRARY] = scenes_library;
     node[group_name][MODELS_LIBRARY] = models_library;
     node[group_name][MESHES_LIBRARY] = meshes_library;
     node[group_name][TEXTURES_LIBRARY] = textures_library;
@@ -174,7 +181,7 @@ const char* ResourcesPreferences::GetLibraryPath(Resource::Type type) const
     switch (type)
     {
     case Resource::Type::SCENE:
-        break;
+        return scenes_library.c_str();
     case Resource::Type::MODEL:
         return models_library.c_str();
     case Resource::Type::MESH:

--- a/Source/src/core/preferences/src/ResourcesPreferences.h
+++ b/Source/src/core/preferences/src/ResourcesPreferences.h
@@ -33,6 +33,7 @@ namespace Hachiko
         std::string animations_assets = "assets/animations/";
         std::string skybox_assets     = "assets/skybox/";
 
+        std::string scenes_library     = "library/scenes/";
         std::string models_library     = "library/models/";
         std::string meshes_library     = "library/meshes/";
         std::string textures_library   = "library/textures/";

--- a/Source/src/core/serialization/Definitions.h
+++ b/Source/src/core/serialization/Definitions.h
@@ -80,6 +80,7 @@
 #define THEME_LIGHT "light"
 #define THEME_DARK "dark"
 #define SCENE_BACKGROUND_COLOR "scene_background_color"
+#define SCENE_AUTOSAVE "scene_autosave"
 
 // Resources
 #define RESOURCES_NODE "resources"

--- a/Source/src/core/serialization/Definitions.h
+++ b/Source/src/core/serialization/Definitions.h
@@ -97,6 +97,7 @@
 #define ANIMATIONS_ASSETS "animations_assets"
 #define SKYBOX_ASSETS "skybox_assets"
 // Library
+#define SCENES_LIBRARY "scenes_library"
 #define MODELS_LIBRARY "models_library"
 #define MESHES_LIBRARY "meshes_library"
 #define TEXTURES_LIBRARY "textures_library"
@@ -137,6 +138,7 @@
 #define SCENE_NAME "scene_name"
 #define UNNAMED_SCENE "UnnamedScene"
 #define ROOT_ID "root_id"
+#define SCENE_TEMP_NAME "temp_scene"
 
 // Game Object
 #define GAME_OBJECT_NAME "name"

--- a/Source/src/modules/ModuleSceneManager.cpp
+++ b/Source/src/modules/ModuleSceneManager.cpp
@@ -152,14 +152,12 @@ void Hachiko::ModuleSceneManager::LoadScene(const char* file_path)
 
 void Hachiko::ModuleSceneManager::SaveScene()
 {
-    Scene* save_scene = main_scene;
-
     if (IsScenePlaying())
     {
-        save_scene = serializer->Load(StringUtils::Concat(preferences->GetLibraryPath(Resource::Type::SCENE), SCENE_TEMP_NAME, SCENE_EXTENSION).c_str());
+        LoadScene(StringUtils::Concat(preferences->GetLibraryPath(Resource::Type::SCENE), SCENE_TEMP_NAME, SCENE_EXTENSION).c_str());
     }
 
-    serializer->Save(save_scene);
+    serializer->Save(main_scene);
 }
 
 void Hachiko::ModuleSceneManager::SaveScene(const char* file_path)

--- a/Source/src/modules/ModuleSceneManager.cpp
+++ b/Source/src/modules/ModuleSceneManager.cpp
@@ -52,7 +52,7 @@ void Hachiko::ModuleSceneManager::AttemptScenePlay()
         game_state.SetEventData<GameStateEventPayload>(GameStateEventPayload::State::STARTED);
         App->event->Publish(game_state);
 
-        SaveScene(ASSETS_FOLDER_SCENES "tmp_scene.scene");
+        SaveScene(StringUtils::Concat(preferences->GetLibraryPath(Resource::Type::SCENE), SCENE_TEMP_NAME, SCENE_EXTENSION).c_str());
         
         GameTimer::Start();
     }
@@ -76,7 +76,7 @@ void Hachiko::ModuleSceneManager::AttemptSceneStop()
 
         GameTimer::Stop();
 
-        LoadScene(ASSETS_FOLDER_SCENES "tmp_scene.scene");
+        LoadScene(StringUtils::Concat(preferences->GetLibraryPath(Resource::Type::SCENE), SCENE_TEMP_NAME, SCENE_EXTENSION).c_str());
     }
 }
 
@@ -107,6 +107,7 @@ bool Hachiko::ModuleSceneManager::CleanUp()
     EditorPreferences* pref = App->preferences->GetEditorPreference();
     pref->SetAutosave(scene_autosave);
     
+    // TODO: Remove temp_scene.scene from disk
     RELEASE(main_scene);
     RELEASE(serializer);
     return true;
@@ -135,7 +136,7 @@ void Hachiko::ModuleSceneManager::SaveScene()
 
     if (IsScenePlaying())
     {
-        save_scene = serializer->Load(ASSETS_FOLDER_SCENES "tmp_scene.scene");
+        save_scene = serializer->Load(StringUtils::Concat(preferences->GetLibraryPath(Resource::Type::SCENE), SCENE_TEMP_NAME, SCENE_EXTENSION).c_str());
     }
 
     serializer->Save(save_scene);

--- a/Source/src/modules/ModuleSceneManager.h
+++ b/Source/src/modules/ModuleSceneManager.h
@@ -59,12 +59,15 @@ namespace Hachiko
 
         void SwitchTo(const char* file_path);
 
+        void OptionsMenu();
+
     private:
         Scene* main_scene = nullptr;
         SceneSerializer* serializer = nullptr;
         ResourcesPreferences* preferences = nullptr;
 
         bool scene_ready_to_load = false;
+        bool scene_autosave = false;
         std::string scene_to_load;
     };
 } // namespace Hachiko

--- a/Source/src/ui/WindowConfiguration.cpp
+++ b/Source/src/ui/WindowConfiguration.cpp
@@ -5,13 +5,15 @@
 #include "modules/ModuleProgram.h"
 #include "modules/ModuleCamera.h"
 #include "modules/ModuleWindow.h"
+#include "modules/ModuleSceneManager.h"
 
 #include "components/ComponentCamera.h"
+#include "core/preferences/src/EditorPreferences.h"
 
 Hachiko::WindowConfiguration::WindowConfiguration() :
-    Window("Configuration", true) {}
-
-Hachiko::WindowConfiguration::~WindowConfiguration() = default;
+    Window("Configuration", true)
+{
+}
 
 void Hachiko::WindowConfiguration::Update()
 {
@@ -21,6 +23,8 @@ void Hachiko::WindowConfiguration::Update()
         if (ImGui::CollapsingHeader("Scene"))
         {
             App->renderer->OptionsMenu();
+            ImGui::Separator();
+            App->scene_manager->OptionsMenu();
             ImGui::Separator();
             ImGui::Text("Shader Options");
             App->program->OptionsMenu();

--- a/Source/src/ui/WindowConfiguration.h
+++ b/Source/src/ui/WindowConfiguration.h
@@ -7,8 +7,7 @@ namespace Hachiko
     {
     public:
         WindowConfiguration();
-
-        ~WindowConfiguration() override;
+        ~WindowConfiguration() override = default;
         void Update() override;
     };
 }


### PR DESCRIPTION
- Add autosave checkbox in windows configuration and save it on setting file he.cfg
- When closing the engine and is playing, first load temp_scene.scene then save it
- File temp_scene.scene is now saved in library/scenes to avoid tracking it