### PR TITLE
Adding GameObject Instantiate & CreateChild Methods

### DIFF
--- a/Gameplay/PlayerController.cpp
+++ b/Gameplay/PlayerController.cpp
@@ -135,6 +135,11 @@ void Hachiko::Scripting::PlayerController::OnUpdate()
 		_is_falling = !_is_falling;
 	}
 
+	if (Input::GetKeyDown(Input::KeyCode::KEY_G))
+	{
+		GameObject::Instantiate();
+	}
+
 	// TODO: Uncomment this in the next PR after adding the new scenes with
 	// YAML based serialization.
 	/*if (current_position.y < -20)

--- a/Gameplay/PlayerController.cpp
+++ b/Gameplay/PlayerController.cpp
@@ -135,9 +135,18 @@ void Hachiko::Scripting::PlayerController::OnUpdate()
 		_is_falling = !_is_falling;
 	}
 
+	static int times_hit_g = 0;
 	if (Input::GetKeyDown(Input::KeyCode::KEY_G))
 	{
-		GameObject::Instantiate();
+		std::string name = "GameObject ";
+		
+		name += std::to_string(times_hit_g);
+		
+		times_hit_g++;
+
+		GameObject* created_game_object = GameObject::Instantiate();
+
+		created_game_object->SetName(name);
 	}
 
 	// TODO: Uncomment this in the next PR after adding the new scenes with

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -242,6 +242,13 @@ void Hachiko::GameObject::Update()
         OnTransformUpdated();
     }
 
+    // NOTE: It is weird that a non-sense nullptr exception we were facing is 
+    // solved by converting the for loop for children vector to use the follow
+    // ing for loop instead of range based and iterator based ones. Thanks to 
+    // Vicenc for coming up with this approach. Maybe we should convert all 
+    // vector loops to be like the ones following.
+    // TODO: Ask this to the teachers.
+
     for (int i = 0; i < components.size(); ++i)
     {
         components[i]->Update();

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -88,7 +88,8 @@ Hachiko::GameObject* Hachiko::GameObject::CreateChild()
 
 Hachiko::GameObject* Hachiko::GameObject::Instantiate()
 {
-    return App->scene_manager->GetActiveScene()->GetRoot()->CreateChild();
+    return App->scene_manager->GetActiveScene()->CreateNewGameObject(
+        App->scene_manager->GetActiveScene()->GetRoot(), "GameObject");
 }
 
 void Hachiko::GameObject::SetNewParent(GameObject* new_parent)

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -89,7 +89,7 @@ Hachiko::GameObject* Hachiko::GameObject::CreateChild()
 Hachiko::GameObject* Hachiko::GameObject::Instantiate()
 {
     return App->scene_manager->GetActiveScene()->CreateNewGameObject(
-        App->scene_manager->GetActiveScene()->GetRoot(), "GameObject");
+        nullptr, "GameObject");
 }
 
 void Hachiko::GameObject::SetNewParent(GameObject* new_parent)
@@ -242,16 +242,16 @@ void Hachiko::GameObject::Update()
         OnTransformUpdated();
     }
 
-    for (Component* component : components)
+    for (int i = 0; i < components.size(); ++i)
     {
-        component->Update();
+        components[i]->Update();
     }
 
-    for (GameObject* child : children)
+    for (int i = 0; i < children.size(); ++i)
     {
-        if (child->IsActive())
+        if (children[i]->IsActive())
         {
-            child->Update();
+            children[i]->Update();
         }
     }
 }

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -88,8 +88,7 @@ Hachiko::GameObject* Hachiko::GameObject::CreateChild()
 
 Hachiko::GameObject* Hachiko::GameObject::Instantiate()
 {
-    return App->scene_manager->GetActiveScene()->CreateNewGameObject(
-        nullptr, "GameObject");
+    return App->scene_manager->GetActiveScene()->GetRoot()->CreateChild();
 }
 
 void Hachiko::GameObject::SetNewParent(GameObject* new_parent)

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -76,6 +76,21 @@ void Hachiko::GameObject::RemoveChild(GameObject* game_object)
     children.erase(std::remove(children.begin(), children.end(), game_object), children.end());
 }
 
+Hachiko::GameObject* Hachiko::GameObject::CreateChild()
+{
+    GameObject* new_child = new GameObject(this);
+    // Ensure that child's scene_owner is same with this GameObject's 
+    // scene_owner:
+    new_child->scene_owner = scene_owner;
+
+    return new_child;
+}
+
+Hachiko::GameObject* Hachiko::GameObject::Instantiate()
+{
+    return App->scene_manager->GetActiveScene()->GetRoot()->CreateChild();
+}
+
 void Hachiko::GameObject::SetNewParent(GameObject* new_parent)
 {
     if (new_parent == parent)

--- a/Source/src/core/GameObject.h
+++ b/Source/src/core/GameObject.h
@@ -17,42 +17,53 @@
 
 namespace Hachiko
 {
-    class ComponentTransform;
-    class ComponentCamera;
-    class Program;
-    class Scene;
+class ComponentTransform;
+class ComponentCamera;
+class Program;
+class Scene;
 
-    class HACHIKO_API GameObject final : public ISerializable
-    {
-        friend class Component;
+class HACHIKO_API GameObject final : public ISerializable
+{
+    friend class Component;
 
-    public:
-        GameObject(const char* name = "Unnamed");
-        GameObject(GameObject* parent,
-                   const float4x4& transform, 
-                   const char* name = "Unnamed", 
-                   UID uid = UUID::GenerateUID());
-        GameObject(GameObject* parent,
-                   const char* name = "Unnamed",
-                   UID uid = UUID::GenerateUID(),
-                   const float3& translation = float3::zero,
-                   const Quat& rotation = Quat::identity,
-                   const float3& scale = float3::one);
-        virtual ~GameObject();
+public:
+    GameObject(const char* name = "Unnamed");
+    GameObject(GameObject* parent,
+                const float4x4& transform, 
+                const char* name = "Unnamed", 
+                UID uid = UUID::GenerateUID());
+    GameObject(GameObject* parent,
+                const char* name = "Unnamed",
+                UID uid = UUID::GenerateUID(),
+                const float3& translation = float3::zero,
+                const Quat& rotation = Quat::identity,
+                const float3& scale = float3::one);
+    virtual ~GameObject();
 
     void SetNewParent(GameObject* new_parent);
 
     void AddComponent(Component* component);
     bool AttemptRemoveComponent(Component* component);
-
-    Component* CreateComponent(Component::Type type);
     /// <summary>
-    /// Do not use this unless it's mandatory. Use AttemptRemoveComponent 
+    /// Do not use this unless it's mandatory. Use AttemptRemoveComponent
     /// instead.
     /// </summary>
     /// <param name="component">Component to be removed.</param>
     void ForceRemoveComponent(Component* component);
+
+    Component* CreateComponent(Component::Type type);
     void RemoveChild(GameObject* gameObject);
+
+    /// <summary>
+    /// Creates a new GameObject as child of the root of current Scene.
+    /// </summary>
+    /// <returns>Created GameObject.</returns>
+    static GameObject* Instantiate();
+    /// <summary>
+    /// Creates a new GameObject as child of this GameObject.
+    /// </summary>
+    /// <returns>Created GameObject.</returns>
+    GameObject* CreateChild();
 
     void Start();
     void Update();

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -26,6 +26,9 @@ Hachiko::Scene::Scene()
     , loaded(false)
     , name(UNNAMED_SCENE)
 {
+    // Root's scene_owner should always be this scene:
+    root->scene_owner = this;
+
     // TODO: Send hardcoded values to preferences
     quadtree->SetBox(AABB(float3(-500, -100, -500), float3(500, 250, 500)));
 }
@@ -50,6 +53,7 @@ void Hachiko::Scene::DestroyGameObject(GameObject* game_object) const
     {
         App->editor->SetSelectedGO(nullptr);
     }
+
     quadtree->Remove(game_object);
 }
 
@@ -87,10 +91,13 @@ void Hachiko::Scene::AddGameObject(GameObject* new_object, GameObject* parent) c
 
 Hachiko::GameObject* Hachiko::Scene::CreateNewGameObject(GameObject* parent, const char* name)
 {
-    // It will insert itself into quadtree on first bounding box update
-    const auto game_object = new GameObject(parent ? parent : root, name);
-    game_object->scene_owner = this;
-    return game_object;
+    GameObject* final_parent = parent != nullptr ? parent : root;
+    GameObject* new_game_object = final_parent->CreateChild();
+
+    new_game_object->SetName(name);
+
+    // This will insert itself into quadtree on first bounding box update:
+    return new_game_object;
 }
 
 void Hachiko::Scene::HandleInputModel(ResourceModel* model)


### PR DESCRIPTION
Added GameObject::Instantiate and GameObject::CreateChild, which will make things easier on scripting side.

## How to Test:
1. Make sure you build Hachiko and Gameplay.
2. Run the engine.
3. Create a game object on an empty scene and attach a "PlayerController" script to it.
4. Go into play mode, press stop, go in to play mode again ( there is a bug with recent rm updates that blocks scripts from updating on the first run of the game, which is fixed with #81 )
5. Hit G key multiple times to see if it adds new game objects to the scene.