### PR TITLE
Handle spaces in the path in gameplay script

### DIFF
--- a/Gameplay/Gameplay.vcxproj
+++ b/Gameplay/Gameplay.vcxproj
@@ -94,7 +94,7 @@
       <AdditionalLibraryDirectories>$(OutDir)..\;$(SolutionDir)vendors\glew-2.1.0\lib;$(SolutionDir)vendors\DevIL\lib;$(SolutionDir)vendors\SDL\lib;$(SolutionDir)vendors\assimp\lib;$(SolutionDir)vendors\optick\lib;$(SolutionDir)vendors\yaml-cpp\lib\x64\Debug</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>call $(ProjectDir)buildEvents\generate_code.bat;</Command>
+      <Command>call "$(ProjectDir)buildEvents\generate_code.bat";</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>xcopy "$(TargetDir)\$(TargetName).exp" "$(TargetDir)..\" /Y

--- a/Gameplay/buildEvents/generate_code.bat
+++ b/Gameplay/buildEvents/generate_code.bat
@@ -1,5 +1,5 @@
 pushd "%~dp0" 
 set current_dir=%cd%
 @REM py.exe %current_dir%\run_code_generation.py
-%current_dir%\run_code_generation.exe
+"%current_dir%\run_code_generation.exe"
 popd


### PR DESCRIPTION
I can't build Gameplay project becasue of a failure on the script. By adding double quotes to the script and configuration it works fine, due to we can handle directories with spaces in between.
If you wonder why I don't remove the spaces on the bloody folder, it's because I can't, I have everything under a One Drive folder I cannot rename.
This should be an harmless change, but pls compile it once just in case.
Thanks!