### PR TITLE
Fix navmesh import loading only meshes

### DIFF
--- a/Source/src/Batching/TextureBatch.cpp
+++ b/Source/src/Batching/TextureBatch.cpp
@@ -8,9 +8,8 @@
 #include "Modules/ModuleProgram.h"
 #include "Modules/ModuleTexture.h"
 
-Hachiko::TextureBatch::~TextureBatch() 
+Hachiko::TextureBatch::~TextureBatch()
 {
-
     for (auto& resource : resources)
     {
         delete resource.second;
@@ -29,6 +28,11 @@ Hachiko::TextureBatch::~TextureBatch()
 
 void Hachiko::TextureBatch::AddMaterial(const ResourceMaterial* resource_material)
 {
+    if (!resource_material)
+    {
+        return;
+    }
+
     if (resource_material->HasDiffuse())
     {
         AddTexture(resource_material->diffuse);
@@ -47,7 +51,7 @@ void Hachiko::TextureBatch::AddMaterial(const ResourceMaterial* resource_materia
     }
 }
 
-void Hachiko::TextureBatch::AddTexture(const ResourceTexture* texture) 
+void Hachiko::TextureBatch::AddTexture(const ResourceTexture* texture)
 {
     auto it = resources.find(texture);
 
@@ -220,6 +224,11 @@ void Hachiko::TextureBatch::GenerateMaterials(const std::vector<const ComponentM
     {
         const ResourceMaterial* material = components[i]->GetResourceMaterial();
 
+        if (!material)
+        {
+            continue;
+        }
+
         materials[i].diffuse_color = material->diffuse_color;
         materials[i].specular_color = material->specular_color;
         materials[i].emissive_color = material->emissive_color;
@@ -277,7 +286,7 @@ void Hachiko::TextureBatch::UpdateBuffers(bool use_first_segment, unsigned compo
 
 void Hachiko::TextureBatch::BindTextures()
 {
-    const std::vector<int> texture_slots = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+    const std::vector<int> texture_slots = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
     App->program->GetMainProgram()->BindUniformInts("allMyTextures", texture_arrays.size(), &texture_slots[0]);
 
     for (unsigned i = 0; i < texture_arrays.size(); ++i)

--- a/Source/src/Batching/TextureBatch.h
+++ b/Source/src/Batching/TextureBatch.h
@@ -25,24 +25,24 @@ namespace Hachiko
 
         struct Material
         {
-            float4 diffuse_color;
-            float4 specular_color;
-            float4 emissive_color;
-            unsigned diffuse_flag;
-            unsigned specular_flag;
-            unsigned normal_flag;
-            unsigned metallic_flag;
-            unsigned emissive_flag;
+            float4 diffuse_color = float4::zero;
+            float4 specular_color = float4::zero;
+            float4 emissive_color = float4::zero;
+            unsigned diffuse_flag = false;
+            unsigned specular_flag = false;
+            unsigned normal_flag = false;
+            unsigned metallic_flag = false;
+            unsigned emissive_flag = false;
             TexAddress diffuse_map;
             TexAddress specular_map;
             TexAddress normal_map;
             TexAddress metallic_map;
             TexAddress emissive_map;
-            float smoothness;
-            float metalness_value;
-            unsigned is_metallic;
-            unsigned smoothness_alpha;
-            unsigned is_transparent;
+            float smoothness = 0.f;
+            float metalness_value = 0.f;
+            unsigned is_metallic = false;
+            unsigned smoothness_alpha = 0;
+            unsigned is_transparent = 0;
             //unsigned padding[3];
         };
 
@@ -64,9 +64,9 @@ namespace Hachiko
 
         void BindTextures();
         void BindBuffers(bool use_first_segment, int component_count);
-        
+
         bool EqualLayout(const TextureArray& texuteLayout, const ResourceTexture& texture);
-        
+
         std::map<const ResourceTexture*, TexAddress*> resources; // contains all the Texture resources and their address
         std::vector<TextureArray*> texture_arrays; // contains all the texture arrays
 

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -415,7 +415,7 @@ void Hachiko::GameObject::Save(YAML::Node& node, bool as_prefab) const
     }
 }
 
-void Hachiko::GameObject::Load(const YAML::Node& node, bool as_prefab)
+void Hachiko::GameObject::Load(const YAML::Node& node, bool as_prefab, bool meshes_only)
 {   
     const YAML::Node components_node = node[COMPONENT_NODE];
     for (unsigned i = 0; i < components_node.size(); ++i)
@@ -435,7 +435,16 @@ void Hachiko::GameObject::Load(const YAML::Node& node, bool as_prefab)
 
         Component* component = nullptr;
 
-        if (type == Component::Type::SCRIPT)
+        if (meshes_only)
+        {
+            if (type == Component::Type::MESH_RENDERER)
+            {
+                component = CreateComponent(type);
+            }
+            continue;
+        }
+
+        else if(type == Component::Type::SCRIPT)
         {
             std::string script_name =
                 components_node[i][SCRIPT_NAME].as<std::string>();

--- a/Source/src/core/GameObject.h
+++ b/Source/src/core/GameObject.h
@@ -93,7 +93,7 @@ namespace Hachiko
         }
 
         void Save(YAML::Node& node, bool as_prefab = false) const;
-        void Load(const YAML::Node& node, bool as_prefab = false);
+        void Load(const YAML::Node& node, bool as_prefab = false, bool meshes_only = false);
 
 
         [[nodiscard]] const std::vector<Component*>& GetComponents() const

--- a/Source/src/core/Scene.h
+++ b/Source/src/core/Scene.h
@@ -114,7 +114,7 @@ namespace Hachiko
         }
 
         void Save(YAML::Node& node);
-        void Load(const YAML::Node& node);
+        void Load(const YAML::Node& node, bool meshes_only = false);
 
         void GetNavmeshData(std::vector<float>& scene_vertices, std::vector<int>& scene_triangles, std::vector<float>& scene_normals, AABB& scene_bounds);
 

--- a/Source/src/core/preferences/src/ResourcesPreferences.cpp
+++ b/Source/src/core/preferences/src/ResourcesPreferences.cpp
@@ -6,18 +6,17 @@
 using namespace Hachiko;
 
 const std::map<Resource::AssetType, std::string> ResourcesPreferences::assets_paths = {
-    {Resource::AssetType::SCENE, ASSETS_FOLDER_SCENE},
     {Resource::AssetType::MODEL, ASSETS_FOLDER_MODEL},
     {Resource::AssetType::TEXTURE, ASSETS_FOLDER_TEXTURE},
     {Resource::AssetType::VIDEO, ASSETS_FOLDER_VIDEO},
     {Resource::AssetType::MATERIAL, ASSETS_FOLDER_MATERIAL},
-    // {Resource::AssetType::SKYBOX, ASSETS_FOLDER_SKYBOX},
+    {Resource::AssetType::SKYBOX, ASSETS_FOLDER_SKYBOX},
     {Resource::AssetType::FONT, ASSETS_FOLDER_FONT},
     {Resource::AssetType::PREFAB, ASSETS_FOLDER_PREFAB},
+    {Resource::AssetType::SCENE, ASSETS_FOLDER_SCENE},
 };
 
-const std::map<Resource::Type, std::string> ResourcesPreferences::lib_paths = {
-    {Resource::Type::SCENE, LIBRARY_FOLDER_SCENE},
+const std::map<Resource::Type, std::string> ResourcesPreferences::lib_paths = {    
     {Resource::Type::MESH, LIBRARY_FOLDER_MESH},
     {Resource::Type::TEXTURE, LIBRARY_FOLDER_TEXTURE},
     {Resource::Type::VIDEO, LIBRARY_FOLDER_VIDEO},
@@ -27,6 +26,7 @@ const std::map<Resource::Type, std::string> ResourcesPreferences::lib_paths = {
     {Resource::Type::FONT, LIBRARY_FOLDER_FONT},
     {Resource::Type::NAVMESH, LIBRARY_FOLDER_NAVMESH},
     {Resource::Type::PREFAB, LIBRARY_FOLDER_PREFAB},
+    {Resource::Type::SCENE, LIBRARY_FOLDER_SCENE},
 };
 
 ResourcesPreferences::ResourcesPreferences()

--- a/Source/src/importers/SceneImporter.cpp
+++ b/Source/src/importers/SceneImporter.cpp
@@ -26,7 +26,8 @@ void Hachiko::SceneImporter::Import(const char* path, YAML::Node& meta)
     Scene* temp_scene = new Scene();
     // Cant load a scene that is not imported yet
     const ResourceScene* scene = static_cast<const ResourceScene*>(Load(scene_uid));
-    temp_scene->Load(scene->scene_data);
+    constexpr bool meshes_only = true;
+    temp_scene->Load(scene->scene_data, meshes_only);
     navmesh_importer.CreateNavmeshFromScene(temp_scene, navmesh_id);
     delete temp_scene;
     delete scene;

--- a/Source/src/modules/ModuleResources.cpp
+++ b/Source/src/modules/ModuleResources.cpp
@@ -226,14 +226,19 @@ void Hachiko::ModuleResources::AssetsLibraryCheck()
 
     // Ignores files that dont need any short of importing themselves
     // Metas are searched for based on what's on assets
-    std::vector<std::string> ignore_extensions {"meta"};
-    PathNode assets_folder = FileSystem::GetAllFiles(ASSETS_FOLDER, nullptr, &ignore_extensions);
-    GenerateLibrary(assets_folder);
+    std::vector<std::string> ignore_extensions {"meta"};    
 
+    // Call it this way to control asset import order (we need meshes to exist to import scene navmesh)
+    const auto& asset_paths = preferences->GetAssetsPathsMap();
+    for (auto it = asset_paths.begin(); it != asset_paths.end(); ++it)
+    {
+        const PathNode folder = FileSystem::GetAllFiles(it->second.c_str(), nullptr, &ignore_extensions);
+        GenerateLibrary(folder);
+    }
     HE_LOG("Assets/Library check finished.");
 }
 
-void Hachiko::ModuleResources::GenerateLibrary(const PathNode& folder) 
+void Hachiko::ModuleResources::GenerateLibrary(const PathNode& folder)
 {
     // Iterate all files found in assets except metas and scene
     for (const PathNode& path_node : folder.children)

--- a/Source/src/modules/ModuleWindow.h
+++ b/Source/src/modules/ModuleWindow.h
@@ -69,6 +69,6 @@ namespace Hachiko
         int max_width{};
         int max_height{};
         int refresh_rate{};
-        bool vsync{};
+        bool vsync = true;
     };
 }

--- a/Source/src/resources/Resource.h
+++ b/Source/src/resources/Resource.h
@@ -36,7 +36,7 @@ namespace Hachiko
             // SHADER = 5,
             // AUDIO = 6,
             VIDEO = 7,
-            // SKYBOX = 8,
+            SKYBOX = 8,
             FONT = 9,
             PREFAB = 10,
         };


### PR DESCRIPTION
We will only load mesh components when loading the temporary the scene for navmesh importing.
This prevents other developers from having to worry about it (sorry xd)

Update: Also predefined an asset import order, we need to make sure meshes (model assets) are imported before importing scenes