### PR TITLE
Keep current navmesh on stop

### DIFF
--- a/Source/src/importers/SceneImporter.cpp
+++ b/Source/src/importers/SceneImporter.cpp
@@ -11,8 +11,8 @@ void Hachiko::SceneImporter::Import(const char* path, YAML::Node& meta)
     // Only 1 scene per scene asset will exist
     static const int scene_resource_index = 0;
     static const int navmesh_resource_index = 1;
-    UID scene_uid = ManageResourceUID(Resource::Type::SCENE, scene_resource_index, meta);    
-    FileSystem::Copy(path, GetResourcePath(Resource::Type::SCENE, scene_uid).c_str());
+    UID scene_uid = ManageResourceUID(Resource::Type::SCENE, scene_resource_index, meta);
+    std::string resource_path = GetResourcePath(Resource::Type::SCENE, scene_uid).c_str();
 
     YAML::Node node = YAML::LoadFile(path);
     if (!node[NAVMESH_ID].IsDefined())
@@ -24,13 +24,12 @@ void Hachiko::SceneImporter::Import(const char* path, YAML::Node& meta)
     NavmeshImporter navmesh_importer;
 
     Scene* temp_scene = new Scene();
-    // Cant load a scene that is not imported yet
-    const ResourceScene* scene = static_cast<const ResourceScene*>(Load(scene_uid));
     constexpr bool meshes_only = true;
-    temp_scene->Load(scene->scene_data, meshes_only);
+    temp_scene->Load(node, meshes_only);
     navmesh_importer.CreateNavmeshFromScene(temp_scene, navmesh_id);
+
+    FileSystem::Save(resource_path.c_str(), node);
     delete temp_scene;
-    delete scene;
 }
 
 void Hachiko::SceneImporter::Save(UID id, const Resource* resource)

--- a/Source/src/modules/ModuleNavigation.cpp
+++ b/Source/src/modules/ModuleNavigation.cpp
@@ -143,7 +143,7 @@ void Hachiko::ModuleNavigation::SetNavmesh(ResourceNavMesh* new_reosurce)
 void Hachiko::ModuleNavigation::RebuildCurrentNavmesh(Scene* scene)
 {
     // Builds navmesh without getting it from library
-    ResourceNavMesh* resource_navmesh = App->navigation->BuildNavmeshResource(scene);
+    ResourceNavMesh* resource_navmesh = BuildNavmeshResource(scene);
     App->navigation->SetNavmesh(resource_navmesh);
 }
 

--- a/Source/src/modules/ModuleSceneManager.cpp
+++ b/Source/src/modules/ModuleSceneManager.cpp
@@ -214,7 +214,9 @@ void Hachiko::ModuleSceneManager::ReloadScene()
 {
     // Use the scene resource refreshed when play is pressed to restore og state
     // Basically scene serialized in memory
-    LoadScene(scene_resource);
+    // Keeps the currently defined navmesh since the one saved in library is from the last time we saved
+    constexpr bool keep_navmesh = true;
+    LoadScene(scene_resource, keep_navmesh);
 }
 
 void Hachiko::ModuleSceneManager::OptionsMenu()
@@ -232,10 +234,9 @@ void Hachiko::ModuleSceneManager::OptionsMenu()
     // Skybox
     ImGui::Separator();
     main_scene->GetSkybox()->DrawImGui();
-    //
 }
 
-void Hachiko::ModuleSceneManager::LoadScene(ResourceScene* new_resource)
+void Hachiko::ModuleSceneManager::LoadScene(ResourceScene* new_resource, bool keep_navmesh)
 {
     SetSceneResource(new_resource);
 
@@ -243,14 +244,20 @@ void Hachiko::ModuleSceneManager::LoadScene(ResourceScene* new_resource)
     if (scene_resource)
     {
         new_scene->Load(scene_resource->scene_data);
-        App->navigation->SetNavmesh(scene_resource->scene_data[NAVMESH_ID].as<UID>());
+        if (!keep_navmesh)
+        {
+            App->navigation->SetNavmesh(scene_resource->scene_data[NAVMESH_ID].as<UID>());
+        }
     }
     else
     {
         // This removes current navmesh
         GameObject* camera_go = new_scene->CreateNewGameObject(new_scene->GetRoot(), "Main Camera");
         camera_go->CreateComponent(Component::Type::CAMERA);
-        App->navigation->SetNavmesh(nullptr);
+        if (!keep_navmesh)
+        {
+            App->navigation->SetNavmesh(nullptr);
+        }
     }
 
     ChangeMainScene(new_scene);

--- a/Source/src/modules/ModuleSceneManager.h
+++ b/Source/src/modules/ModuleSceneManager.h
@@ -9,6 +9,7 @@ namespace Hachiko
     class ComponentCamera;
     class ResourcesPreferences;
     class ResourceScene;
+    class ResourceNavMesh;
 
     class ModuleSceneManager final : public Module
     {
@@ -60,7 +61,7 @@ namespace Hachiko
         void OptionsMenu();
 
     private:
-        void LoadScene(ResourceScene* scene);
+        void LoadScene(ResourceScene* scene, bool keep_navmesh = false);
         void ChangeMainScene(Scene* new_scene);
         // Deletes current resource it it doesnt come from resource manager (for now assume it when id 0)
         void SetSceneResource(ResourceScene* scene);
@@ -72,6 +73,7 @@ namespace Hachiko
         bool scene_ready_to_load = false;
         bool scene_autosave = false;
         ResourceScene* scene_resource;
+        ResourceNavMesh* navmesh_resource;
         UID scene_to_load_id;
     };
 } // namespace Hachiko


### PR DESCRIPTION
Scene importer was acting weird. And it reloaded from disk lastest navmesh on stop when it made more sense to keep using the most recently created.

Also fixed a bug with scene importer that did not properly refresh the asset

**Note:** If for some reason ur previously saved navmesh still giving issues remove navmesh files from library and it should sort itself out