### PR TITLE
Fix: dont render inactive gameobjects or invisible meshes

### DIFF
--- a/Source/src/core/rendering/RenderList.cpp
+++ b/Source/src/core/rendering/RenderList.cpp
@@ -62,7 +62,7 @@ void Hachiko::RenderList::CollectMeshes(ComponentCamera* camera, const float3& c
 void Hachiko::RenderList::CollectMesh(const float3& camera_pos, GameObject* game_object)
 {
     ComponentMeshRenderer* mesh_renderer = game_object->GetComponent<ComponentMeshRenderer>();
-    if (!mesh_renderer || !mesh_renderer->IsVisible())
+    if (!mesh_renderer)
     {
         return;
     }
@@ -71,6 +71,11 @@ void Hachiko::RenderList::CollectMesh(const float3& camera_pos, GameObject* game
 
 void Hachiko::RenderList::CollectMesh(const float3& camera_pos, ComponentMeshRenderer* mesh)
 {
+    if (!mesh->GetGameObject()->IsActive() || !mesh->IsVisible())
+    {
+        return;
+    }
+    
     GameObject* game_object = mesh->GetGameObject();
     RenderTarget target;
     target.name = game_object->GetName().c_str();


### PR DESCRIPTION
Lowered the check to the method used by gameobject collect and quadtree collect and added go active check.
Sorry for small pr