### PR TITLE
Implemented cleaner label generation for script fields shown on editor.

### DIFF
--- a/Gameplay/generated/Factory.cpp
+++ b/Gameplay/generated/Factory.cpp
@@ -5,6 +5,7 @@
 #include "CrystalExplosion.h"
 #include "DynamicCamera.h"
 #include "EnemyController.h"
+#include "FancyLights.h"
 #include "MainMenuManager.h"
 #include "PlayerAnimationManager.h"
 #include "PlayerCamera.h"
@@ -37,6 +38,11 @@ Hachiko::Scripting::Script* InstantiateScript(Hachiko::GameObject* script_owner,
 	if (script_name == "EnemyController")
 	{
 		return new Hachiko::Scripting::EnemyController(script_owner);
+	}
+
+	if (script_name == "FancyLights")
+	{
+		return new Hachiko::Scripting::FancyLights(script_owner);
 	}
 
 	if (script_name == "MainMenuManager")

--- a/Gameplay/generated/GeneratedEditor.cpp
+++ b/Gameplay/generated/GeneratedEditor.cpp
@@ -4,6 +4,7 @@
 #include "CrystalExplosion.h"
 #include "DynamicCamera.h"
 #include "EnemyController.h"
+#include "FancyLights.h"
 #include "MainMenuManager.h"
 #include "PlayerAnimationManager.h"
 #include "PlayerCamera.h"
@@ -13,103 +14,109 @@
 
 void Hachiko::Scripting::BackToMainMenu::OnEditor()
 {
-	Editor::Show<ComponentButton>("_button_back", "ComponentButton*", _button_back);
+	Editor::Show<ComponentButton>("Button Back", "ComponentButton*", _button_back);
 }
 
 void Hachiko::Scripting::BugAnimationManager::OnEditor()
 {
-	Editor::Show<ComponentAnimation>("_animator", "ComponentAnimation*", _animator);
-	Editor::Show("_state_string", _state_string);
-	Editor::Show("_idle_index", _idle_index);
-	Editor::Show("_attacking_index", _attacking_index);
+	Editor::Show<ComponentAnimation>("Animator", "ComponentAnimation*", _animator);
+	Editor::Show("State String", _state_string);
+	Editor::Show("Idle Index", _idle_index);
+	Editor::Show("Attacking Index", _attacking_index);
 }
 
 void Hachiko::Scripting::CrystalExplosion::OnEditor()
 {
-	Editor::Show("_player", _player);
-	Editor::Show("_explosion_crystal", _explosion_crystal);
-	Editor::Show("_static_crystal", _static_crystal);
-	Editor::Show("_crashing_index", _crashing_index);
-	Editor::Show("_detecting_radius", _detecting_radius);
-	Editor::Show("_explosion_radius", _explosion_radius);
-	Editor::Show("_explosive_crystal", _explosive_crystal);
+	Editor::Show("Player", _player);
+	Editor::Show("Explosion Crystal", _explosion_crystal);
+	Editor::Show("Static Crystal", _static_crystal);
+	Editor::Show("Crashing Index", _crashing_index);
+	Editor::Show("Detecting Radius", _detecting_radius);
+	Editor::Show("Explosion Radius", _explosion_radius);
+	Editor::Show("Explosive Crystal", _explosive_crystal);
 }
 
 void Hachiko::Scripting::DynamicCamera::OnEditor()
 {
-	Editor::Show("_start_point", _start_point);
-	Editor::Show("_end_point", _end_point);
-	Editor::Show("_speed", _speed);
-	Editor::Show("_lerp_position", _lerp_position);
+	Editor::Show("Start Point", _start_point);
+	Editor::Show("End Point", _end_point);
+	Editor::Show("Speed", _speed);
+	Editor::Show("Lerp Position", _lerp_position);
 }
 
 void Hachiko::Scripting::EnemyController::OnEditor()
 {
-	Editor::Show("_aggro_range", _aggro_range);
-	Editor::Show("_attack_range", _attack_range);
-	Editor::Show("_spawn_pos", _spawn_pos);
-	Editor::Show("_spawn_is_initial", _spawn_is_initial);
-	Editor::Show("_player", _player);
-	Editor::Show("_attack_animation_duration", _attack_animation_duration);
-	Editor::Show("_attack_animation_timer", _attack_animation_timer);
+	Editor::Show("Aggro Range", _aggro_range);
+	Editor::Show("Attack Range", _attack_range);
+	Editor::Show("Spawn Pos", _spawn_pos);
+	Editor::Show("Spawn Is Initial", _spawn_is_initial);
+	Editor::Show("Player", _player);
+	Editor::Show("Attack Animation Duration", _attack_animation_duration);
+	Editor::Show("Attack Animation Timer", _attack_animation_timer);
+}
+
+void Hachiko::Scripting::FancyLights::OnEditor()
+{
+	Editor::Show("Rotate On Y", _rotate_on_y);
+	Editor::Show("Angle", _angle);
 }
 
 void Hachiko::Scripting::MainMenuManager::OnEditor()
 {
-	Editor::Show("_state_changed", _state_changed);
-	Editor::Show("_main_background", _main_background);
-	Editor::Show("_button_background", _button_background);
-	Editor::Show<ComponentButton>("_button_play", "ComponentButton*", _button_play);
-	Editor::Show<ComponentButton>("_button_quit", "ComponentButton*", _button_quit);
-	Editor::Show<ComponentButton>("_button_settings", "ComponentButton*", _button_settings);
-	Editor::Show<ComponentButton>("_button_credits", "ComponentButton*", _button_credits);
-	Editor::Show("_settings", _settings);
-	Editor::Show("_credits", _credits);
-	Editor::Show<ComponentButton>("_button_back", "ComponentButton*", _button_back);
+	Editor::Show("State Changed", _state_changed);
+	Editor::Show("Main Background", _main_background);
+	Editor::Show("Button Background", _button_background);
+	Editor::Show<ComponentButton>("Button Play", "ComponentButton*", _button_play);
+	Editor::Show<ComponentButton>("Button Quit", "ComponentButton*", _button_quit);
+	Editor::Show<ComponentButton>("Button Settings", "ComponentButton*", _button_settings);
+	Editor::Show<ComponentButton>("Button Credits", "ComponentButton*", _button_credits);
+	Editor::Show("Settings", _settings);
+	Editor::Show("Credits", _credits);
+	Editor::Show<ComponentButton>("Button Back", "ComponentButton*", _button_back);
 }
 
 void Hachiko::Scripting::PlayerAnimationManager::OnEditor()
 {
-	Editor::Show<ComponentAnimation>("_animator", "ComponentAnimation*", _animator);
-	Editor::Show("_state_string", _state_string);
-	Editor::Show("_idle_index", _idle_index);
-	Editor::Show("_walking_index", _walking_index);
-	Editor::Show("_dashing_index", _dashing_index);
-	Editor::Show("_melee_index", _melee_index);
-	Editor::Show("_ranged_index", _ranged_index);
+	Editor::Show<ComponentAnimation>("Animator", "ComponentAnimation*", _animator);
+	Editor::Show("State String", _state_string);
+	Editor::Show("Idle Index", _idle_index);
+	Editor::Show("Walking Index", _walking_index);
+	Editor::Show("Dashing Index", _dashing_index);
+	Editor::Show("Melee Index", _melee_index);
+	Editor::Show("Ranged Index", _ranged_index);
 }
 
 void Hachiko::Scripting::PlayerCamera::OnEditor()
 {
-	Editor::Show("_relative_position_to_player", _relative_position_to_player);
-	Editor::Show("_player", _player);
-	Editor::Show("_follow_delay", _follow_delay);
+	Editor::Show("Relative Position To Player", _relative_position_to_player);
+	Editor::Show("Player", _player);
+	Editor::Show("Follow Delay", _follow_delay);
 }
 
 void Hachiko::Scripting::PlayerController::OnEditor()
 {
-	Editor::Show("_movement_speed", _movement_speed);
-	Editor::Show("_attack_indicator", _attack_indicator);
-	Editor::Show("_goal", _goal);
-	Editor::Show("_dash_duration", _dash_duration);
-	Editor::Show("_dash_distance", _dash_distance);
-	Editor::Show("_dash_cooldown", _dash_cooldown);
-	Editor::Show("_max_dash_charges", _max_dash_charges);
-	Editor::Show("_raycast_min_range", _raycast_min_range);
-	Editor::Show("_raycast_max_range", _raycast_max_range);
-	Editor::Show("_attack_radius", _attack_radius);
-	Editor::Show("_attack_cooldown", _attack_cooldown);
-	Editor::Show("_attack_duration", _attack_duration);
-	Editor::Show("_rotation_duration", _rotation_duration);
-	Editor::Show("_camera", _camera);
-	Editor::Show("_ui_damage", _ui_damage);
+	Editor::Show("Movement Speed", _movement_speed);
+	Editor::Show("Attack Indicator", _attack_indicator);
+	Editor::Show("Goal", _goal);
+	Editor::Show("Dash Duration", _dash_duration);
+	Editor::Show("Dash Distance", _dash_distance);
+	Editor::Show("Dash Cooldown", _dash_cooldown);
+	Editor::Show("Max Dash Charges", _max_dash_charges);
+	Editor::Show("Raycast Min Range", _raycast_min_range);
+	Editor::Show("Raycast Max Range", _raycast_max_range);
+	Editor::Show("Attack Radius", _attack_radius);
+	Editor::Show("Attack Cooldown", _attack_cooldown);
+	Editor::Show("Attack Duration", _attack_duration);
+	Editor::Show("Rotation Duration", _rotation_duration);
+	Editor::Show("Camera", _camera);
+	Editor::Show("Ui Damage", _ui_damage);
 }
 
 void Hachiko::Scripting::PlayerSoundManager::OnEditor()
 {
-	Editor::Show<ComponentAudioSource>("_audio_source", "ComponentAudioSource*", _audio_source);
-	Editor::Show("_step_frequency", _step_frequency);
-	Editor::Show("_melee_frequency", _melee_frequency);
-	Editor::Show("_ranged_frequency", _ranged_frequency);
-	Editor::Show("_timer", _timer);
+	Editor::Show<ComponentAudioSource>("Audio Source", "ComponentAudioSource*", _audio_source);
+	Editor::Show("Step Frequency", _step_frequency);
+	Editor::Show("Melee Frequency", _melee_frequency);
+	Editor::Show("Ranged Frequency", _ranged_frequency);
+	Editor::Show("Timer", _timer);
 }

--- a/Gameplay/generated/SaveAndLoadMethods.cpp
+++ b/Gameplay/generated/SaveAndLoadMethods.cpp
@@ -6,6 +6,7 @@
 #include "CrystalExplosion.h"
 #include "DynamicCamera.h"
 #include "EnemyController.h"
+#include "FancyLights.h"
 #include "MainMenuManager.h"
 #include "PlayerAnimationManager.h"
 #include "PlayerCamera.h"
@@ -256,6 +257,26 @@ void Hachiko::Scripting::EnemyController::OnLoad()
 	if (load_node["'_attack_animation_timer@float'"].IsDefined())
 	{
 		_attack_animation_timer = load_node["'_attack_animation_timer@float'"].as<float>();
+	}
+}
+
+void Hachiko::Scripting::FancyLights::OnSave(YAML::Node& node) const
+{
+	node["'_rotate_on_y@bool'"] = _rotate_on_y;
+
+	node["'_angle@float'"] = _angle;
+}
+
+void Hachiko::Scripting::FancyLights::OnLoad()
+{
+	if (load_node["'_rotate_on_y@bool'"].IsDefined())
+	{
+		_rotate_on_y = load_node["'_rotate_on_y@bool'"].as<bool>();
+	}
+
+	if (load_node["'_angle@float'"].IsDefined())
+	{
+		_angle = load_node["'_angle@float'"].as<float>();
 	}
 }
 

--- a/Gameplay/generated/SerializationMethods.cpp
+++ b/Gameplay/generated/SerializationMethods.cpp
@@ -7,6 +7,7 @@
 #include "CrystalExplosion.h"
 #include "DynamicCamera.h"
 #include "EnemyController.h"
+#include "FancyLights.h"
 #include "MainMenuManager.h"
 #include "PlayerAnimationManager.h"
 #include "PlayerCamera.h"
@@ -359,6 +360,38 @@ void Hachiko::Scripting::EnemyController::SerializeTo(std::unordered_map<std::st
 	serialized_fields["_attack_animation_duration"] = SerializedField(std::string("_attack_animation_duration"), std::make_any<float>(_attack_animation_duration), std::string("float"));
 
 	serialized_fields["_attack_animation_timer"] = SerializedField(std::string("_attack_animation_timer"), std::make_any<float>(_attack_animation_timer), std::string("float"));
+}
+
+void Hachiko::Scripting::FancyLights::DeserializeFrom(std::unordered_map<std::string, SerializedField>& serialized_fields)
+{
+	Hachiko::Scripting::Script::DeserializeFrom(serialized_fields);
+
+	if(serialized_fields.find("_rotate_on_y") != serialized_fields.end())
+	{
+		const SerializedField& _rotate_on_y_sf = serialized_fields["_rotate_on_y"];
+		if (_rotate_on_y_sf.type_name == "bool")
+		{
+			_rotate_on_y = std::any_cast<bool>(_rotate_on_y_sf.copy);
+		}
+	}
+
+	if(serialized_fields.find("_angle") != serialized_fields.end())
+	{
+		const SerializedField& _angle_sf = serialized_fields["_angle"];
+		if (_angle_sf.type_name == "float")
+		{
+			_angle = std::any_cast<float>(_angle_sf.copy);
+		}
+	}
+}
+
+void Hachiko::Scripting::FancyLights::SerializeTo(std::unordered_map<std::string, SerializedField>& serialized_fields)
+{
+	Hachiko::Scripting::Script::SerializeTo(serialized_fields);
+
+	serialized_fields["_rotate_on_y"] = SerializedField(std::string("_rotate_on_y"), std::make_any<bool>(_rotate_on_y), std::string("bool"));
+
+	serialized_fields["_angle"] = SerializedField(std::string("_angle"), std::make_any<float>(_angle), std::string("float"));
 }
 
 void Hachiko::Scripting::MainMenuManager::DeserializeFrom(std::unordered_map<std::string, SerializedField>& serialized_fields)


### PR DESCRIPTION
As per @armandojaga's wish, the code generation script for scripts now generates cleaner editor labels for the fields. 

The label cleaning takes underscores and camelCase or PascalCase strings into account and generates a label that is separated with spaces and casing that looks like "This Is A Label". Some examples are:
![image](https://user-images.githubusercontent.com/42971567/172078171-a32f1a55-358f-4bbc-8373-fdbf37162cb3.png)
![image](https://user-images.githubusercontent.com/42971567/172078177-ffba7a0c-1097-431d-a071-8d91f28aa5c3.png)
![image](https://user-images.githubusercontent.com/42971567/172078190-7ebf3e8e-f5a6-4d4b-b171-233ef2cf5de1.png)
![image](https://user-images.githubusercontent.com/42971567/172078216-a5bcc92d-50eb-469a-842a-369acf9fa5f8.png)
![image](https://user-images.githubusercontent.com/42971567/172078822-b962ca31-0884-47b8-88aa-d7ba7d7da203.png)
![image](https://user-images.githubusercontent.com/42971567/172078842-a1aad204-852e-43c8-9924-96c320b0bb7d.png)
![image](https://user-images.githubusercontent.com/42971567/172078990-b20b7a77-0abd-4b06-8d9f-25100e06ec0b.png)
![image](https://user-images.githubusercontent.com/42971567/172079002-121263c2-697b-4f15-8f0a-8281352c9c8c.png)
![image](https://user-images.githubusercontent.com/42971567/172079053-edfc1d78-3a01-4cfd-aa56-1483e04c9238.png)
![image](https://user-images.githubusercontent.com/42971567/172079057-42e4b55e-1dd0-48ec-8fbc-1e02f210c394.png)

The field labels now look like: 
![image](https://user-images.githubusercontent.com/42971567/172078094-7b789e9b-9dbd-4d67-bdf6-4dc44b441608.png)
![image](https://user-images.githubusercontent.com/42971567/172079273-20e7df2e-504d-4ab8-a72d-77badea031aa.png)