### PR TITLE
Closing engine while playing with agents caused crash

### DIFF
--- a/Source/src/Application.cpp
+++ b/Source/src/Application.cpp
@@ -32,6 +32,7 @@ Hachiko::Application::Application()
     modules.push_back(camera = new ModuleCamera());
     modules.push_back(resources = new ModuleResources());
     modules.push_back(audio = new ModuleAudio());
+    modules.push_back(navigation = new ModuleNavigation());
     modules.push_back(scene_manager = new ModuleSceneManager());
     modules.push_back(program = new ModuleProgram());
     modules.push_back(debug_draw = new ModuleDebugDraw());
@@ -39,7 +40,6 @@ Hachiko::Application::Application()
     modules.push_back(event = new ModuleEvent());
     modules.push_back(ui = new ModuleUserInterface()); 
     modules.push_back(debug_mode = new ModuleDebugMode());
-    modules.push_back(navigation = new ModuleNavigation());
     preferences = new PreferenceManager(SETTINGS_FILE_PATH);
 
 }

--- a/Source/src/modules/ModuleSceneManager.cpp
+++ b/Source/src/modules/ModuleSceneManager.cpp
@@ -130,6 +130,11 @@ bool Hachiko::ModuleSceneManager::CleanUp()
         SaveScene();
     }
 
+    if (IsScenePlaying())
+    {
+        main_scene->Stop();
+    }
+
     EditorPreferences* editor_prefs = App->preferences->GetEditorPreference();
     editor_prefs->SetAutosave(scene_autosave);
     // If it was a temporary scene it will set id to 0 which will generate a new temporary scene on load


### PR DESCRIPTION
2 Fixes
- Make sure scene is stopped when closing the engine
- Clear navigation after scene has managed cleaning its agents (automatic on stop)