### PR TITLE
Optimization: Smarter Quadtree

### DIFF
--- a/Source/src/components/ComponentMeshRenderer.cpp
+++ b/Source/src/components/ComponentMeshRenderer.cpp
@@ -351,7 +351,7 @@ void Hachiko::ComponentMeshRenderer::UpdateBoundingBoxes()
     Scene* scene = game_object->scene_owner;
     if (scene)
     {
-        const Quadtree* quadtree = scene->GetQuadtree();
+        Quadtree* quadtree = scene->GetQuadtree();
         quadtree->Remove(this);
         quadtree->Insert(this);
     }

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -320,6 +320,7 @@ void Hachiko::Scene::Update()
 {
     OPTICK_CATEGORY("UpdateScene", Optick::Category::Scene);
     root->Update();
+    quadtree->Refresh();
 }
 
 Hachiko::Scene::Memento* Hachiko::Scene::CreateSnapshot()

--- a/Source/src/core/rendering/Quadtree.cpp
+++ b/Source/src/core/rendering/Quadtree.cpp
@@ -119,7 +119,7 @@ void Hachiko::QuadtreeNode::RearangeChildren()
         }
 
         // If it intersects all there is no point in moving downwards
-        if (intersection_count == 4)
+        if (intersection_count > 1)
         {
             ++it;
             continue;

--- a/Source/src/core/rendering/Quadtree.cpp
+++ b/Source/src/core/rendering/Quadtree.cpp
@@ -25,18 +25,16 @@ void Hachiko::QuadtreeNode::Insert(const std::unordered_set<ComponentMeshRendere
 
 void Hachiko::QuadtreeNode::Remove(const std::unordered_set<ComponentMeshRenderer*>& to_remove)
 {
-    for (auto it = meshes.rbegin(); it != meshes.rend();)
+    auto it = meshes.rbegin();
+    while (it != meshes.rend())
     {
         ComponentMeshRenderer* mesh = *it;
-        if (to_remove.find(mesh) != to_remove.end())
+        if (to_remove.find(mesh) == to_remove.end())
         {
-            
-            std::advance(it, 1);
-            meshes.erase(it.base());
+            ++it;
             continue;
         }
-        ++it;
-        
+        it = decltype(it)(meshes.erase((it + 1).base()));
     }
     
     if (!IsLeaf())
@@ -106,8 +104,8 @@ void Hachiko::QuadtreeNode::RearangeChildren()
         CreateChildren();
     }
     
-    
-    for (auto it = meshes.rbegin(); it != meshes.rend();)
+    auto it = meshes.rbegin();
+    while (it != meshes.rend())
     {
         ComponentMeshRenderer* mesh = *it;
         int intersection_count = 0;
@@ -127,9 +125,7 @@ void Hachiko::QuadtreeNode::RearangeChildren()
             ++it;
             continue;
         }
-
-        std::advance(it, 1);
-        meshes.erase(it.base());
+        it = decltype(it)(meshes.erase((it + 1).base()));
 
         for (int i = 0; i < static_cast<int>(Quadrants::COUNT); ++i)
         {

--- a/Source/src/core/rendering/Quadtree.cpp
+++ b/Source/src/core/rendering/Quadtree.cpp
@@ -25,12 +25,14 @@ void Hachiko::QuadtreeNode::Insert(const std::unordered_set<ComponentMeshRendere
 
 void Hachiko::QuadtreeNode::Remove(const std::unordered_set<ComponentMeshRenderer*>& to_remove)
 {
-    for (auto it = meshes.begin(); it != meshes.end();)
+    for (auto it = meshes.rbegin(); it != meshes.rend();)
     {
         ComponentMeshRenderer* mesh = *it;
         if (to_remove.find(mesh) != to_remove.end())
         {
-            it = meshes.erase(it);
+            
+            std::advance(it, 1);
+            meshes.erase(it.base());
             continue;
         }
         ++it;
@@ -104,7 +106,8 @@ void Hachiko::QuadtreeNode::RearangeChildren()
         CreateChildren();
     }
     
-    for (auto it = meshes.begin(); it != meshes.end();)
+    
+    for (auto it = meshes.rbegin(); it != meshes.rend();)
     {
         ComponentMeshRenderer* mesh = *it;
         int intersection_count = 0;
@@ -124,7 +127,10 @@ void Hachiko::QuadtreeNode::RearangeChildren()
             ++it;
             continue;
         }
-        it = meshes.erase(it);
+
+        std::advance(it, 1);
+        meshes.erase(it.base());
+
         for (int i = 0; i < static_cast<int>(Quadrants::COUNT); ++i)
         {
             if (intersects[i])

--- a/Source/src/core/rendering/Quadtree.h
+++ b/Source/src/core/rendering/Quadtree.h
@@ -4,7 +4,7 @@
 #include "components/ComponentMeshRenderer.h"
 
 #include <MathGeoLib.h>
-#include <list>
+#include <unordered_set>
 
 #define QUADTREE_MAX_ITEMS 16
 #define QUADTREE_MIN_SIZE 50.f
@@ -26,8 +26,8 @@ namespace Hachiko
         QuadtreeNode(const AABB& box, QuadtreeNode* parent, int depth);
         ~QuadtreeNode();
 
-        void Insert(const std::set<ComponentMeshRenderer*>& to_insert);
-        void Remove(const std::set<ComponentMeshRenderer*>& to_remove);
+        void Insert(const std::unordered_set<ComponentMeshRenderer*>& to_insert);
+        void Remove(const std::unordered_set<ComponentMeshRenderer*>& to_remove);
         void CreateChildren();
         void RearangeChildren();
 
@@ -41,7 +41,7 @@ namespace Hachiko
             return box;
         }
 
-        [[nodiscard]] const std::list<ComponentMeshRenderer*>& GetMeshes() const
+        [[nodiscard]] const std::vector<ComponentMeshRenderer*>& GetMeshes() const
         {
             return meshes;
         }
@@ -56,12 +56,10 @@ namespace Hachiko
         void DebugDraw();
 
     private:
-        void Invalidate();
-        bool dirty = true;
         int depth = 0;
         AABB box;
         QuadtreeNode* parent = nullptr;
-        std::list<ComponentMeshRenderer*> meshes {};
+        std::vector<ComponentMeshRenderer*> meshes {};
     };
 
     class Quadtree
@@ -85,8 +83,8 @@ namespace Hachiko
         void DebugDraw() const;
 
     private:
-        std::set<ComponentMeshRenderer*> to_remove = {};
-        std::set<ComponentMeshRenderer*> to_insert = {};
+        std::unordered_set<ComponentMeshRenderer*> to_remove = {};
+        std::unordered_set<ComponentMeshRenderer*> to_insert = {};
         QuadtreeNode* root = nullptr;
     };
 

--- a/Source/src/core/rendering/Quadtree.h
+++ b/Source/src/core/rendering/Quadtree.h
@@ -6,9 +6,8 @@
 #include <MathGeoLib.h>
 #include <list>
 
-#define QUADTREE_MAX_ITEMS 8
+#define QUADTREE_MAX_ITEMS 16
 #define QUADTREE_MIN_SIZE 50.f
-#define QUADTREE_MAX_DEPTH 10
 
 namespace Hachiko
 {
@@ -27,8 +26,8 @@ namespace Hachiko
         QuadtreeNode(const AABB& box, QuadtreeNode* parent, int depth);
         ~QuadtreeNode();
 
-        void Insert(ComponentMeshRenderer* mesh);
-        void Remove(ComponentMeshRenderer* mesh);
+        void Insert(const std::set<ComponentMeshRenderer*>& to_insert);
+        void Remove(const std::set<ComponentMeshRenderer*>& to_remove);
         void CreateChildren();
         void RearangeChildren();
 
@@ -57,6 +56,8 @@ namespace Hachiko
         void DebugDraw();
 
     private:
+        void Invalidate();
+        bool dirty = true;
         int depth = 0;
         AABB box;
         QuadtreeNode* parent = nullptr;
@@ -72,8 +73,9 @@ namespace Hachiko
         void Clear();
         void SetBox(const AABB& box);
 
-        void Insert(ComponentMeshRenderer* mesh) const;
-        void Remove(ComponentMeshRenderer* mesh) const;
+        void Insert(ComponentMeshRenderer* mesh);
+        void Remove(ComponentMeshRenderer* mesh);
+        void Refresh();
 
         [[nodiscard]] QuadtreeNode* GetRoot() const
         {
@@ -83,6 +85,8 @@ namespace Hachiko
         void DebugDraw() const;
 
     private:
+        std::set<ComponentMeshRenderer*> to_remove = {};
+        std::set<ComponentMeshRenderer*> to_insert = {};
         QuadtreeNode* root = nullptr;
     };
 

--- a/Source/src/core/rendering/Quadtree.h
+++ b/Source/src/core/rendering/Quadtree.h
@@ -6,7 +6,7 @@
 #include <MathGeoLib.h>
 #include <unordered_set>
 
-#define QUADTREE_MAX_ITEMS 16
+#define QUADTREE_MAX_ITEMS 8
 #define QUADTREE_MIN_SIZE 50.f
 
 namespace Hachiko


### PR DESCRIPTION
Implemented quadtree in a way that everything is inserted and removed in a single iteration. Full level on debug goes from 5 fps from 20+ which is not much but it helps. Also helps to see all gameobjects that are being changed on quadtree per frame.
Update: also removing meshes vector in reverse order now since it seems to make it faster.

**FPS GAIN** (Estimate in engine mode with resources menu loaded)
Debug + 20
Release + 100

**HOW IT WORKS**
When we call remove and insert we just add them to an unordered set and use these sets 1 time per frame to perform the quadtree operations. If some insert of remove has been done then we also call rearrange children

Next step is managing animated transforms properly