### PR TITLE
Fix: detect when to keep intermediate nodes on import

### DIFF
--- a/Source/src/importers/ModelImporter.h
+++ b/Source/src/importers/ModelImporter.h
@@ -27,6 +27,6 @@ namespace Hachiko
 
     private:
         void ImportModel(const char* path, const aiScene* scene, YAML::Node& meta);
-        void ImportNode(GameObject* parent, const aiScene* scene, const aiNode* assimp_node, YAML::Node& meta, bool load_auxiliar);
+        void ImportNode(GameObject* parent, const aiScene* scene, const aiNode* assimp_node, YAML::Node& meta, bool combine_intermediate_nodes);
     };
 }


### PR DESCRIPTION
We are detecting an animation on all models, this is generally not a huge issue but it made the prefab generation always keep all intermediate nodes (which means tons more of gameobjects per level model). New criteria is to see if there exists at least one bone. Tested it on a level fbx and it didnt store intermediate nodes.