### PR TITLE
Fix: Texture properties serialization

### DIFF
--- a/Game/assets/textures/Baker_house.png.meta
+++ b/Game/assets/textures/Baker_house.png.meta
@@ -2,3 +2,7 @@ asset_hash: 8184352862842450271
 resources:
   - resource_id: 12023432331947101770
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/Details.png.meta
+++ b/Game/assets/textures/Details.png.meta
@@ -2,3 +2,7 @@ asset_hash: 7813985935471110027
 resources:
   - resource_id: 10482571268862899118
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_BaseColor.png.meta
+++ b/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_BaseColor.png.meta
@@ -2,3 +2,7 @@ asset_hash: 9212963030998280176
 resources:
   - resource_id: 7829590593615923966
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Emissive.png.meta
+++ b/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Emissive.png.meta
@@ -2,3 +2,7 @@ asset_hash: 3299873316326951096
 resources:
   - resource_id: 12740366129530358435
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Height.png.meta
+++ b/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Height.png.meta
@@ -2,3 +2,7 @@ asset_hash: 17229295435723154808
 resources:
   - resource_id: 15120671195597507268
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Metallic.png.meta
+++ b/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Metallic.png.meta
@@ -2,3 +2,7 @@ asset_hash: 5030322890318104033
 resources:
   - resource_id: 8789969227512057136
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Normal.png.meta
+++ b/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Normal.png.meta
@@ -2,3 +2,7 @@ asset_hash: 15729649341041341132
 resources:
   - resource_id: 16155281465293442460
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Roughness.png.meta
+++ b/Game/assets/textures/Enemies/Bug/bugBake_low_v04_DefaultMaterial_Roughness.png.meta
@@ -2,3 +2,7 @@ asset_hash: 2638856152943033164
 resources:
   - resource_id: 11428975464017903992
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/ZomBunnyDiffuse.png.meta
+++ b/Game/assets/textures/ZomBunnyDiffuse.png.meta
@@ -2,3 +2,7 @@ asset_hash: 16930821496603869512
 resources:
   - resource_id: 5316918336019857045
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/ZomBunnyEmissive.png.meta
+++ b/Game/assets/textures/ZomBunnyEmissive.png.meta
@@ -2,3 +2,7 @@ asset_hash: 6663659729613256311
 resources:
   - resource_id: 2137336431232494422
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/ZomBunnyNormals.png.meta
+++ b/Game/assets/textures/ZomBunnyNormals.png.meta
@@ -2,3 +2,7 @@ asset_hash: 14138521546603977019
 resources:
   - resource_id: 556217011129045109
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/ZomBunnyOcclusion.png.meta
+++ b/Game/assets/textures/ZomBunnyOcclusion.png.meta
@@ -2,3 +2,7 @@ asset_hash: 10070982691215120982
 resources:
   - resource_id: 14530860661671552419
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/ZomBunnySpecular.tif.meta
+++ b/Game/assets/textures/ZomBunnySpecular.tif.meta
@@ -2,3 +2,7 @@ asset_hash: 10242126233744188076
 resources:
   - resource_id: 10562313864479859396
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/black-vignette.png.meta
+++ b/Game/assets/textures/black-vignette.png.meta
@@ -2,3 +2,7 @@ asset_hash: 11721617816751087324
 resources:
   - resource_id: 10523760409150182962
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/chunkLiefe_on.png.meta
+++ b/Game/assets/textures/chunkLiefe_on.png.meta
@@ -2,3 +2,7 @@ asset_hash: 15426094434702084775
 resources:
   - resource_id: 2627443166751613316
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_df.png.meta
+++ b/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_df.png.meta
@@ -2,3 +2,7 @@ asset_hash: 16825016976032115599
 resources:
   - resource_id: 879487886243846185
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_explotion_df.png.meta
+++ b/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_explotion_df.png.meta
@@ -2,3 +2,7 @@ asset_hash: 3471217529879990344
 resources:
   - resource_id: 11073166836157285318
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_m.png.meta
+++ b/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_m.png.meta
@@ -2,3 +2,7 @@ asset_hash: 16819955931943659158
 resources:
   - resource_id: 827734173276011101
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_n.png.meta
+++ b/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_n.png.meta
@@ -2,3 +2,7 @@ asset_hash: 5630361448501429802
 resources:
   - resource_id: 3997003743442544213
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_s.png.meta
+++ b/Game/assets/textures/crystal/CrystalSpike_txt/crystalSpike_mesh_s.png.meta
@@ -2,3 +2,7 @@ asset_hash: 3213995265405488512
 resources:
   - resource_id: 2842664124103588567
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/crystal/crystalShort_mesh_n.png.meta
+++ b/Game/assets/textures/crystal/crystalShort_mesh_n.png.meta
@@ -2,3 +2,7 @@ asset_hash: 5630361448501429802
 resources:
   - resource_id: 10146733887574542897
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/mcLow_df.png.meta
+++ b/Game/assets/textures/mcLow_df.png.meta
@@ -2,3 +2,7 @@ asset_hash: 11715488988494607127
 resources:
   - resource_id: 13939380227490299706
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/mcLow_e.png.meta
+++ b/Game/assets/textures/mcLow_e.png.meta
@@ -2,3 +2,7 @@ asset_hash: 3528093594044976605
 resources:
   - resource_id: 6765710703793009634
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/mcLow_h.png.meta
+++ b/Game/assets/textures/mcLow_h.png.meta
@@ -2,3 +2,7 @@ asset_hash: 15013774174619693071
 resources:
   - resource_id: 17805530246545066495
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/mcLow_n.png.meta
+++ b/Game/assets/textures/mcLow_n.png.meta
@@ -2,3 +2,7 @@ asset_hash: 9785750812204661841
 resources:
   - resource_id: 6126653541125285381
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Game/assets/textures/mcLow_s.png.meta
+++ b/Game/assets/textures/mcLow_s.png.meta
@@ -2,3 +2,7 @@ asset_hash: 14095599916207662559
 resources:
   - resource_id: 6625923854291750242
     resource_type: 2
+mag_filter: 9987
+min_filter: 9729
+wrap_mode: 10496
+extra_hash: 4852379206516900628

--- a/Source/src/core/serialization/Definitions.h
+++ b/Source/src/core/serialization/Definitions.h
@@ -12,9 +12,13 @@
 #define RESOURCE_ID "resource_id"
 #define RESOURCE_TYPE "resource_type"
 #define ASSET_HASH "asset_hash"
+#define EXTRA_HASH "extra_hash"
 
 // Texture
 #define TEXTURE_FILE_PATH "file_path"
+#define TEXTURE_MIN_FILTER "min_filter"
+#define TEXTURE_MAG_FILTER "mag_filter"
+#define TEXTURE_WRAP_MODE "wrap_mode"
 
 // Model
 #define MESHES "meshes"

--- a/Source/src/importers/TextureImporter.cpp
+++ b/Source/src/importers/TextureImporter.cpp
@@ -13,14 +13,20 @@ void Hachiko::TextureImporter::Import(const char* path, YAML::Node& meta)
     static const int resource_index = 0;
     UID uid = ManageResourceUID(Resource::Type::TEXTURE, resource_index, meta);
     std::string extension = FileSystem::GetFileExtension(path);
-    // TODO: could we extract ModuleTexture functionality to this importer?
 
-    ResourceTexture* texture = App->texture->ImportTextureResource(uid, path, extension != TIF_TEXTURE_EXTENSION);
+    // TODO: could we extract ModuleTexture functionality to this importer?
+    ResourceTexture* texture = App->texture->ImportTextureResource(uid, path, meta, extension != TIF_TEXTURE_EXTENSION);
      
+    meta[TEXTURE_MAG_FILTER] = texture->min_filter;
+    meta[TEXTURE_MIN_FILTER] = texture->mag_filter;
+    meta[TEXTURE_WRAP_MODE] = texture->wrap;
+
     if (texture != nullptr)
     {
         Save(uid, texture);
     }
+
+    meta[EXTRA_HASH] = GetExtraHash(meta);
 
     delete texture;
 }
@@ -75,6 +81,35 @@ Hachiko::Resource* Hachiko::TextureImporter::Load(UID id)
     return texture;
 }
 
+uint64_t Hachiko::TextureImporter::GetExtraHash(const YAML::Node& meta)
+{
+    std::vector<unsigned> properties;
+
+    if (meta[TEXTURE_MAG_FILTER].IsDefined())
+    {
+        properties.push_back(meta[TEXTURE_MIN_FILTER].as<unsigned>());
+    }
+
+    if (meta[TEXTURE_WRAP_MODE].IsDefined())
+    {
+        properties.push_back(meta[TEXTURE_WRAP_MODE].as<unsigned>());
+    }
+
+    if (meta[TEXTURE_WRAP_MODE].IsDefined())
+    {
+        properties.push_back(meta[TEXTURE_MIN_FILTER].as<unsigned>());
+    }
+    uint64_t extra_hash = FileSystem::HashFromBuffer((char*)properties.data(), properties.size() * sizeof(unsigned));
+    return extra_hash;
+}
+
+bool Hachiko::TextureImporter::OutdatedExtraHash(const YAML::Node& meta)
+{
+    uint64_t previous_extra_hash = meta[EXTRA_HASH].IsDefined() ? meta[EXTRA_HASH].as<uint64_t>() : 0;
+    uint64_t extra_hash = GetExtraHash(meta);
+    return previous_extra_hash != extra_hash;
+}
+
 void Hachiko::TextureImporter::Save(UID id, const Hachiko::Resource* res)
 {
     const ResourceTexture* texture = static_cast<const ResourceTexture*>(res);
@@ -115,6 +150,21 @@ void Hachiko::TextureImporter::Save(UID id, const Hachiko::Resource* res)
 
     FileSystem::Save(file_path.c_str(), file_buffer, file_size);
     delete[] file_buffer;
+}
+
+void Hachiko::TextureImporter::SaveTextureAsset(const ResourceTexture* texture)
+{
+    // TODO: Make more eleganto
+    // Update the texture meta if edited from engine
+    // Separated because normal import already manages meta file and we need to have the data before it is loaded for import
+    // Here we only add to meta the required params and then manage import normally    
+    std::string meta_path = StringUtils::Concat(texture->path, META_EXTENSION);
+    YAML::Node meta_node = YAML::LoadFile(meta_path);
+    meta_node[TEXTURE_MAG_FILTER] = texture->min_filter;
+    meta_node[TEXTURE_MIN_FILTER] = texture->mag_filter;
+    meta_node[TEXTURE_WRAP_MODE] = texture->wrap;
+    FileSystem::Save(meta_path.c_str(), meta_node);
+    App->resources->ImportAssetFromAnyPath(texture->path);
 }
 
 

--- a/Source/src/importers/TextureImporter.h
+++ b/Source/src/importers/TextureImporter.h
@@ -4,6 +4,8 @@
 
 namespace Hachiko
 {
+    class ResourceTexture;
+    
     class TextureImporter final : public Importer
     {
         friend class MaterialImporter;
@@ -17,8 +19,13 @@ namespace Hachiko
         void Import(const char* path, YAML::Node& meta) override;
         Resource* Load(UID id) override;
 
+        uint64_t GetExtraHash(const YAML::Node& meta);
+        bool OutdatedExtraHash(const YAML::Node& meta);
+
         void Save(UID id, const Resource* resource) override;
+        void SaveTextureAsset(const ResourceTexture* texture);
         ResourceTexture* CreateTextureAssetFromAssimp(const std::string& model_path, const aiMaterial* ai_material, aiTextureType type);
     private:
+        
     };
 }

--- a/Source/src/modules/ModuleResources.cpp
+++ b/Source/src/modules/ModuleResources.cpp
@@ -234,11 +234,6 @@ GameObject* Hachiko::ModuleResources::InstantiatePrefab(UID prefab_uid, GameObje
     return importer_manager.prefab.CreateObjectFromPrefab(prefab_uid, parent);
 }
 
-void Hachiko::ModuleResources::SaveResource(const Resource* resource) const 
-{
-    importer_manager.SaveResource(resource->GetID(), resource);
-}
-
 void Hachiko::ModuleResources::AssetsLibraryCheck()
 {
     HE_LOG("Assets/Library check...");
@@ -309,6 +304,18 @@ std::vector<UID> Hachiko::ModuleResources::ImportAsset(const std::string& asset_
     {
         UpdateAssetHash(asset_path.c_str(), meta_node);
         return ImportAssetResources(std::filesystem::path(asset_path), meta_node);
+    }
+
+    // If the asset serializes user defined data on meta (textures) we have extra checks for it)
+    if (type == Resource::AssetType::TEXTURE)
+    {
+        TextureImporter tex_importer;
+
+        if (tex_importer.OutdatedExtraHash(meta_node))
+        {
+            UpdateAssetHash(asset_path.c_str(), meta_node);
+            return ImportAssetResources(std::filesystem::path(asset_path), meta_node);
+        }
     }
     
     // Reimport if any lib file is missing

--- a/Source/src/modules/ModuleTexture.cpp
+++ b/Source/src/modules/ModuleTexture.cpp
@@ -41,7 +41,7 @@ bool Hachiko::ModuleTexture::CleanUp()
     return true;
 }
 
-Hachiko::ResourceTexture* Hachiko::ModuleTexture::ImportTextureResource(UID uid, const char* path, bool flip)
+Hachiko::ResourceTexture* Hachiko::ModuleTexture::ImportTextureResource(UID uid, const char* path, YAML::Node& meta, bool flip)
 {
     std::filesystem::path texture_path = path;
 
@@ -55,10 +55,9 @@ Hachiko::ResourceTexture* Hachiko::ModuleTexture::ImportTextureResource(UID uid,
     ResourceTexture* texture = new ResourceTexture(uid);
     texture->path = path;
     texture->SetName(texture_path.filename().replace_extension().string().c_str());
-    texture->min_filter = GL_LINEAR_MIPMAP_LINEAR;
-    texture->mag_filter = GL_LINEAR;
-    texture->wrap = GL_CLAMP;
-
+    texture->min_filter = meta[TEXTURE_MAG_FILTER].IsDefined() ? meta[TEXTURE_MAG_FILTER].as<unsigned>() : GL_LINEAR_MIPMAP_LINEAR;
+    texture->mag_filter = meta[TEXTURE_MIN_FILTER].IsDefined() ? meta[TEXTURE_MIN_FILTER].as<unsigned>() : GL_LINEAR;
+    texture->wrap = meta[TEXTURE_WRAP_MODE].IsDefined() ? meta[TEXTURE_WRAP_MODE].as<unsigned>() : GL_CLAMP;
     texture->bpp = ilGetInteger(IL_IMAGE_BPP);
     texture->width = ilGetInteger(IL_IMAGE_WIDTH);
     texture->height = ilGetInteger(IL_IMAGE_HEIGHT);

--- a/Source/src/modules/ModuleTexture.h
+++ b/Source/src/modules/ModuleTexture.h
@@ -54,7 +54,7 @@ namespace Hachiko
         bool Init() override;
         bool CleanUp() override;
 
-        static ResourceTexture* ImportTextureResource(UID uid, const char* path, bool flip = true);
+        static ResourceTexture* ImportTextureResource(UID uid, const char* path, YAML::Node& meta, bool flip = true);
         static ResourceSkybox* ImportSkyboxResource(UID uid, const char* path, bool flip = true);
 
         static TextureCube LoadCubeMap(TextureCube& cube);

--- a/Source/src/resources/ResourceTexture.cpp
+++ b/Source/src/resources/ResourceTexture.cpp
@@ -147,6 +147,7 @@ void Hachiko::ResourceTexture::DrawGui()
         // Notify Batch Manager that there is a change so it can rebuild the batches:
         App->scene_manager->GetActiveScene()->OnMeshesChanged();
         // Save the texture if there is a change:
-        App->resources->SaveResource(this);
+        TextureImporter texture_importer;
+        texture_importer.SaveTextureAsset(this);
     }
 }


### PR DESCRIPTION
Since we are crunching ill be brief
Problem: We were not storing the texture properties on assets so they were not known outside local library
**Changes**
- We store those properties on texture meta file (we can not write in the png)
- We have an extra hash of those properties values so the texture asset is always up to date on any machine (ugly to check specific type logic on rm but solid mechanism and needed for now)

Will it break old textures? Nope u covered we good
Is this code kinda XD? Yes but it solves an important problem i can make it better if desired when we have time <3
Why do we store a random ass value? Its just opengl definition value so we dont need to convert