### PR TITLE
Improvement: Quadtree Dirty Flag &Fixes

### DIFF
--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -138,7 +138,7 @@ Hachiko::GameObject* Hachiko::Scene::Raycast(const LineSegment& segment, bool tr
     GameObject* selected = nullptr;
     float closest_hit_distance = inf;
 
-    std::set<GameObject*> game_objects;
+    std::unordered_set<GameObject*> game_objects;
     quadtree->GetIntersections(game_objects, segment);
 
     for (GameObject* game_object : game_objects)

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -138,8 +138,8 @@ Hachiko::GameObject* Hachiko::Scene::Raycast(const LineSegment& segment, bool tr
     GameObject* selected = nullptr;
     float closest_hit_distance = inf;
 
-    std::vector<GameObject*> game_objects;
-    quadtree->GetRoot()->GetIntersections(game_objects, segment);
+    std::set<GameObject*> game_objects;
+    quadtree->GetIntersections(game_objects, segment);
 
     for (GameObject* game_object : game_objects)
     {

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -138,7 +138,7 @@ Hachiko::GameObject* Hachiko::Scene::Raycast(const LineSegment& segment, bool tr
     GameObject* selected = nullptr;
     float closest_hit_distance = inf;
 
-    std::unordered_set<GameObject*> game_objects;
+    std::vector<GameObject*> game_objects;
     quadtree->GetIntersections(game_objects, segment);
 
     for (GameObject* game_object : game_objects)

--- a/Source/src/core/rendering/Quadtree.cpp
+++ b/Source/src/core/rendering/Quadtree.cpp
@@ -83,10 +83,10 @@ void Hachiko::QuadtreeNode::CreateChildren()
 
 void Hachiko::QuadtreeNode::DeleteChildren()
 {
-    RELEASE(children[(int)Quadrants::NW]);
-    RELEASE(children[(int)Quadrants::NE]);
-    RELEASE(children[(int)Quadrants::SE]);
-    RELEASE(children[(int)Quadrants::SW]);
+    RELEASE(children[static_cast<int>(Quadrants::NW)]);
+    RELEASE(children[static_cast<int>(Quadrants::NE)]);
+    RELEASE(children[static_cast<int>(Quadrants::SE)]);
+    RELEASE(children[static_cast<int>(Quadrants::SW)]);
 }
 
 unsigned Hachiko::QuadtreeNode::RearangeChildren()

--- a/Source/src/core/rendering/Quadtree.cpp
+++ b/Source/src/core/rendering/Quadtree.cpp
@@ -125,8 +125,8 @@ unsigned Hachiko::QuadtreeNode::RearangeChildren()
                 }
             }
 
-            // If it intersects all there is no point in moving downwards
-            if (intersection_count == 4)
+            // If it intersects more than desired dont go downwards
+            if (intersection_count > 1)
             {
                 ++it;
                 continue;
@@ -159,7 +159,7 @@ unsigned Hachiko::QuadtreeNode::RearangeChildren()
 }
 
 
-void Hachiko::QuadtreeNode::GetIntersections(std::unordered_set<ComponentMeshRenderer*>& intersected, const Frustum& frustum)
+void Hachiko::QuadtreeNode::GetIntersections(std::vector<ComponentMeshRenderer*>& intersected, const Frustum& frustum)
 {
     if (frustum.Intersects(box))
     {
@@ -167,7 +167,7 @@ void Hachiko::QuadtreeNode::GetIntersections(std::unordered_set<ComponentMeshRen
         {
             if (frustum.Intersects(mesh->GetAABB()))
             {
-                intersected.insert(mesh);
+                intersected.push_back(mesh);
             }
         }
 

--- a/Source/src/core/rendering/Quadtree.h
+++ b/Source/src/core/rendering/Quadtree.h
@@ -22,6 +22,7 @@ namespace Hachiko
 
     class QuadtreeNode
     {
+        friend class Quadtree;
     public:
         QuadtreeNode(const AABB& box, QuadtreeNode* parent, int depth);
         ~QuadtreeNode();
@@ -45,17 +46,20 @@ namespace Hachiko
         {
             return meshes;
         }
-
-        template<typename T>
-        void GetIntersections(std::vector<GameObject*>& objects, const T& primitive) const;
-
-        void GetIntersections(std::vector<ComponentMeshRenderer*>& objects, const Frustum& frustum) const;
-
+        
         QuadtreeNode* children[static_cast<int>(Quadrants::COUNT)] {};
 
         void DebugDraw();
 
     private:
+        template<typename T>
+        void GetIntersections(std::set<GameObject*>& objects, const T& primitive);
+
+        template<typename T>
+        void GetIntersections(std::set<ComponentMeshRenderer*>& meshes, const T& primitive);
+
+        void GetIntersections(std::set<ComponentMeshRenderer*>& objects, const Frustum& frustum);
+
         int depth = 0;
         AABB box;
         QuadtreeNode* parent = nullptr;
@@ -73,23 +77,55 @@ namespace Hachiko
 
         void Insert(ComponentMeshRenderer* mesh);
         void Remove(ComponentMeshRenderer* mesh);
-        void Refresh();
+        
 
-        [[nodiscard]] QuadtreeNode* GetRoot() const
+        [[nodiscard]] QuadtreeNode* GetRoot()
         {
+            if (root)
+            {
+                Refresh();
+            }
             return root;
         }
 
-        void DebugDraw() const;
+        template<typename T>
+        void GetIntersections(std::set<GameObject*>& intersected, const T& primitive);
+
+        template<typename T>
+        void GetIntersections(std::set<ComponentMeshRenderer*>& intersected, const T& primitive);
+
+        void DebugDraw();
 
     private:
+        void Refresh();
         std::unordered_set<ComponentMeshRenderer*> to_remove = {};
         std::unordered_set<ComponentMeshRenderer*> to_insert = {};
         QuadtreeNode* root = nullptr;
     };
 
     template<typename T>
-    void QuadtreeNode::GetIntersections(std::vector<GameObject*>& intersected, const T& primitive) const
+    void Quadtree::GetIntersections(std::set<GameObject*>& intersected, const T& primitive)
+    {
+        if (root)
+        {
+            Refresh();
+            root->GetIntersections(intersected, primitive);
+        }
+        
+    }
+
+    template<typename T>
+    void Quadtree::GetIntersections(std::set<ComponentMeshRenderer*>& intersected, const T& primitive)
+    {
+        if (root)
+        {
+            Refresh();
+            root->GetIntersections(intersected, primitive);
+        }
+    }
+
+    template<typename T>
+    void QuadtreeNode::GetIntersections(std::set<GameObject*>& intersected, const T& primitive)
     {
         if (primitive.Intersects(box))
         {
@@ -98,7 +134,32 @@ namespace Hachiko
             {
                 if (primitive.Intersects(mesh->GetOBB(), near_hit, far_hit))
                 {
-                    intersected.push_back(mesh->GetGameObject());
+                    intersected.insert(mesh->GetGameObject());
+                }
+            }
+
+            // If it has one child all exist
+            if (children[0] != nullptr)
+            {
+                for (int i = 0; i < 4; ++i)
+                {
+                    children[i]->GetIntersections(intersected, primitive);
+                }
+            }
+        }
+    }
+
+    template<typename T>
+    void QuadtreeNode::GetIntersections(std::set<ComponentMeshRenderer*>& intersected, const T& primitive)
+    {
+        if (primitive.Intersects(box))
+        {
+            float near_hit, far_hit;
+            for (ComponentMeshRenderer* mesh : meshes)
+            {
+                if (primitive.Intersects(mesh->GetOBB(), near_hit, far_hit))
+                {
+                    intersected.push_back(mesh);
                 }
             }
 

--- a/Source/src/core/rendering/Quadtree.h
+++ b/Source/src/core/rendering/Quadtree.h
@@ -55,12 +55,12 @@ namespace Hachiko
 
     private:
         template<typename T>
-        void GetIntersections(std::unordered_set<GameObject*>& objects, const T& primitive);
+        void GetIntersections(std::vector<GameObject*>& objects, const T& primitive);
 
         template<typename T>
-        void GetIntersections(std::unordered_set<ComponentMeshRenderer*>& meshes, const T& primitive);
+        void GetIntersections(std::vector<ComponentMeshRenderer*>& meshes, const T& primitive);
 
-        void GetIntersections(std::unordered_set<ComponentMeshRenderer*>& objects, const Frustum& frustum);
+        void GetIntersections(std::vector<ComponentMeshRenderer*>& objects, const Frustum& frustum);
 
         int depth = 0;
         AABB box;
@@ -91,10 +91,10 @@ namespace Hachiko
         }
 
         template<typename T>
-        void GetIntersections(std::unordered_set<GameObject*>& intersected, const T& primitive);
+        void GetIntersections(std::vector<GameObject*>& intersected, const T& primitive);
 
         template<typename T>
-        void GetIntersections(std::unordered_set<ComponentMeshRenderer*>& intersected, const T& primitive);
+        void GetIntersections(std::vector<ComponentMeshRenderer*>& intersected, const T& primitive);
 
         void DebugDraw();
 
@@ -106,7 +106,7 @@ namespace Hachiko
     };
 
     template<typename T>
-    void Quadtree::GetIntersections(std::unordered_set<GameObject*>& intersected, const T& primitive)
+    void Quadtree::GetIntersections(std::vector<GameObject*>& intersected, const T& primitive)
     {
         if (root)
         {
@@ -117,7 +117,7 @@ namespace Hachiko
     }
 
     template<typename T>
-    void Quadtree::GetIntersections(std::unordered_set<ComponentMeshRenderer*>& intersected, const T& primitive)
+    void Quadtree::GetIntersections(std::vector<ComponentMeshRenderer*>& intersected, const T& primitive)
     {
         if (root)
         {
@@ -127,7 +127,7 @@ namespace Hachiko
     }
 
     template<typename T>
-    void QuadtreeNode::GetIntersections(std::unordered_set<GameObject*>& intersected, const T& primitive)
+    void QuadtreeNode::GetIntersections(std::vector<GameObject*>& intersected, const T& primitive)
     {
         if (primitive.Intersects(box))
         {
@@ -136,7 +136,7 @@ namespace Hachiko
             {
                 if (primitive.Intersects(mesh->GetOBB(), near_hit, far_hit))
                 {
-                    intersected.insert(mesh->GetGameObject());
+                    intersected.push_back(mesh->GetGameObject());
                 }
             }
 
@@ -152,7 +152,7 @@ namespace Hachiko
     }
 
     template<typename T>
-    void QuadtreeNode::GetIntersections(std::unordered_set<ComponentMeshRenderer*>& intersected, const T& primitive)
+    void QuadtreeNode::GetIntersections(std::vector<ComponentMeshRenderer*>& intersected, const T& primitive)
     {
         if (primitive.Intersects(box))
         {

--- a/Source/src/core/rendering/Quadtree.h
+++ b/Source/src/core/rendering/Quadtree.h
@@ -7,7 +7,7 @@
 #include <unordered_set>
 
 #define QUADTREE_MAX_ITEMS 8
-#define QUADTREE_MIN_SIZE 50.f
+#define QUADTREE_MAX_DEPTH 8
 
 namespace Hachiko
 {
@@ -23,14 +23,16 @@ namespace Hachiko
     class QuadtreeNode
     {
         friend class Quadtree;
-    public:
+
+    private:
         QuadtreeNode(const AABB& box, QuadtreeNode* parent, int depth);
         ~QuadtreeNode();
 
         void Insert(const std::unordered_set<ComponentMeshRenderer*>& to_insert);
         void Remove(const std::unordered_set<ComponentMeshRenderer*>& to_remove);
         void CreateChildren();
-        void RearangeChildren();
+        void DeleteChildren();
+        unsigned RearangeChildren();
 
         [[nodiscard]] bool IsLeaf() const
         {
@@ -53,12 +55,12 @@ namespace Hachiko
 
     private:
         template<typename T>
-        void GetIntersections(std::set<GameObject*>& objects, const T& primitive);
+        void GetIntersections(std::unordered_set<GameObject*>& objects, const T& primitive);
 
         template<typename T>
-        void GetIntersections(std::set<ComponentMeshRenderer*>& meshes, const T& primitive);
+        void GetIntersections(std::unordered_set<ComponentMeshRenderer*>& meshes, const T& primitive);
 
-        void GetIntersections(std::set<ComponentMeshRenderer*>& objects, const Frustum& frustum);
+        void GetIntersections(std::unordered_set<ComponentMeshRenderer*>& objects, const Frustum& frustum);
 
         int depth = 0;
         AABB box;
@@ -89,10 +91,10 @@ namespace Hachiko
         }
 
         template<typename T>
-        void GetIntersections(std::set<GameObject*>& intersected, const T& primitive);
+        void GetIntersections(std::unordered_set<GameObject*>& intersected, const T& primitive);
 
         template<typename T>
-        void GetIntersections(std::set<ComponentMeshRenderer*>& intersected, const T& primitive);
+        void GetIntersections(std::unordered_set<ComponentMeshRenderer*>& intersected, const T& primitive);
 
         void DebugDraw();
 
@@ -104,7 +106,7 @@ namespace Hachiko
     };
 
     template<typename T>
-    void Quadtree::GetIntersections(std::set<GameObject*>& intersected, const T& primitive)
+    void Quadtree::GetIntersections(std::unordered_set<GameObject*>& intersected, const T& primitive)
     {
         if (root)
         {
@@ -115,7 +117,7 @@ namespace Hachiko
     }
 
     template<typename T>
-    void Quadtree::GetIntersections(std::set<ComponentMeshRenderer*>& intersected, const T& primitive)
+    void Quadtree::GetIntersections(std::unordered_set<ComponentMeshRenderer*>& intersected, const T& primitive)
     {
         if (root)
         {
@@ -125,7 +127,7 @@ namespace Hachiko
     }
 
     template<typename T>
-    void QuadtreeNode::GetIntersections(std::set<GameObject*>& intersected, const T& primitive)
+    void QuadtreeNode::GetIntersections(std::unordered_set<GameObject*>& intersected, const T& primitive)
     {
         if (primitive.Intersects(box))
         {
@@ -150,7 +152,7 @@ namespace Hachiko
     }
 
     template<typename T>
-    void QuadtreeNode::GetIntersections(std::set<ComponentMeshRenderer*>& intersected, const T& primitive)
+    void QuadtreeNode::GetIntersections(std::unordered_set<ComponentMeshRenderer*>& intersected, const T& primitive)
     {
         if (primitive.Intersects(box))
         {

--- a/Source/src/core/rendering/RenderList.cpp
+++ b/Source/src/core/rendering/RenderList.cpp
@@ -11,20 +11,19 @@ void Hachiko::RenderList::PreUpdate()
     polycount_total = 0;
 }
 
-void Hachiko::RenderList::Update(ComponentCamera* camera, QuadtreeNode* quadtree)
+void Hachiko::RenderList::Update(ComponentCamera* camera, Quadtree* quadtree)
 {
     opaque_targets.clear();
     transparent_targets.clear();
-    const Frustum* frustum = camera->GetFrustum();
     const float3 camera_pos = camera->GetGameObject()->GetTransform()->GetGlobalPosition();
     CollectMeshes(camera, camera_pos, quadtree);
 }
 
-void Hachiko::RenderList::CollectMeshes(ComponentCamera* camera, const float3& camera_pos, QuadtreeNode* quadtree)
+void Hachiko::RenderList::CollectMeshes(ComponentCamera* camera, const float3& camera_pos, Quadtree* quadtree)
 {
     const Frustum* frustum = camera->GetFrustum();
 
-    std::vector<ComponentMeshRenderer*> meshes;
+    std::set<ComponentMeshRenderer*> meshes;
 
     quadtree->GetIntersections(meshes, *frustum);
 
@@ -32,26 +31,6 @@ void Hachiko::RenderList::CollectMeshes(ComponentCamera* camera, const float3& c
     {
         CollectMesh(camera_pos, mesh_renderer);
     }
-
-    //const bool quad_inside = frustum->Intersects(quadtree->GetBox());
-    //// Check if node intersects camera
-    //if (quad_inside)
-    //{
-    //    // Check any gameobjects intersect
-    //    for (ComponentMeshRenderer* mesh : quadtree->GetMeshes())
-    //    {
-    //        CollectMesh(camera_pos, mesh);
-    //    }
-
-    //    // Call for all children (What to do if it is duplicated when collecting)?
-    //    if (!quadtree->IsLeaf())
-    //    {
-    //        for (QuadtreeNode* child : quadtree->children)
-    //        {
-    //            CollectMeshes(camera, camera_pos, child);
-    //        }
-    //    }
-    //}
 }
 
 void Hachiko::RenderList::CollectMesh(const float3& camera_pos, ComponentMeshRenderer* mesh_renderer)

--- a/Source/src/core/rendering/RenderList.cpp
+++ b/Source/src/core/rendering/RenderList.cpp
@@ -23,7 +23,7 @@ void Hachiko::RenderList::CollectMeshes(ComponentCamera* camera, const float3& c
 {
     const Frustum* frustum = camera->GetFrustum();
 
-    std::set<ComponentMeshRenderer*> meshes;
+    std::unordered_set<ComponentMeshRenderer*> meshes;
 
     quadtree->GetIntersections(meshes, *frustum);
 

--- a/Source/src/core/rendering/RenderList.cpp
+++ b/Source/src/core/rendering/RenderList.cpp
@@ -23,7 +23,7 @@ void Hachiko::RenderList::CollectMeshes(ComponentCamera* camera, const float3& c
 {
     const Frustum* frustum = camera->GetFrustum();
 
-    std::unordered_set<ComponentMeshRenderer*> meshes;
+    std::vector<ComponentMeshRenderer*> meshes;
 
     quadtree->GetIntersections(meshes, *frustum);
 

--- a/Source/src/core/rendering/RenderList.h
+++ b/Source/src/core/rendering/RenderList.h
@@ -9,6 +9,7 @@ namespace Hachiko
     class GameObject;
     class ComponentMeshRenderer;
     class ComponentCamera;
+    class Quadtree;
     class QuadtreeNode;
 
     struct RenderTarget
@@ -23,7 +24,7 @@ namespace Hachiko
     {
     public:
         void PreUpdate();
-        void Update(ComponentCamera* camera, QuadtreeNode* quadtree);
+        void Update(ComponentCamera* camera, Quadtree* quadtree);
 
         std::vector<RenderTarget>& GetOpaqueTargets()
         {
@@ -46,7 +47,7 @@ namespace Hachiko
         }
 
     private:
-        void CollectMeshes(ComponentCamera* camera, const float3& camera_pos, QuadtreeNode* quadtree);
+        void CollectMeshes(ComponentCamera* camera, const float3& camera_pos, Quadtree* quadtree);
         void CollectMesh(const float3& camera_pos, ComponentMeshRenderer* mesh);
 
         std::vector<RenderTarget> opaque_targets;

--- a/Source/src/modules/ModuleRender.cpp
+++ b/Source/src/modules/ModuleRender.cpp
@@ -230,9 +230,7 @@ void Hachiko::ModuleRender::Draw(Scene* scene, ComponentCamera* camera,
 
     BatchManager* batch_manager = scene->GetBatchManager();
     
-    scene->GetQuadtree()->Refresh();
-
-    render_list.Update(culling, scene->GetQuadtree()->GetRoot());
+    render_list.Update(culling, scene->GetQuadtree());
     
     if (draw_deferred)
     {


### PR DESCRIPTION
Changes:
-  Anytime u access quadtree root or call any of its methods it will be up to date (dirty 🥵  flag like)
- Quadtree child nodes are deleted when empty
- We limit quadtree depth instead of size (thats just personal preference)
- Fixed rearange conditions so quadtree does not instantly push meshes to the maximum possible depth
-  Changed oriented bounding intersect for AABB for consistency and bcs cheaper