### PR TITLE
Feature: Managed Gameobject Destruction and scene change

### DIFF
--- a/Gameplay/BulletController.cpp
+++ b/Gameplay/BulletController.cpp
@@ -47,7 +47,7 @@ void Hachiko::Scripting::BulletController::OnUpdate()
 		if (CheckCollisions())
 		{
 			//	If it hits enemy bullets is destroyed
-			RELEASE(game_object);
+			SceneManagement::Destroy(game_object);
 		}
 
 		_lifetime -= Time::DeltaTime();

--- a/Gameplay/BulletController.cpp
+++ b/Gameplay/BulletController.cpp
@@ -37,6 +37,7 @@ void Hachiko::Scripting::BulletController::OnUpdate()
 		//	Disable
 		game_object->SetActive(false);
 		SceneManagement::Destroy(game_object);
+		return;
 	}
 	else
 	{
@@ -48,6 +49,7 @@ void Hachiko::Scripting::BulletController::OnUpdate()
 		{
 			//	If it hits enemy bullets is destroyed
 			SceneManagement::Destroy(game_object);
+			return;
 		}
 
 		_lifetime -= Time::DeltaTime();
@@ -69,7 +71,11 @@ bool Hachiko::Scripting::BulletController::CheckCollisions()
 		if (enemies_children[i]->active && _collider_radius >= transform->GetGlobalPosition().Distance(enemies_children[i]->GetTransform()->GetGlobalPosition()))
 		{
 			float3 dir = enemies_children[i]->GetTransform()->GetGlobalPosition() - transform->GetGlobalPosition();
-			enemies_children[i]->GetComponent<EnemyController>()->RegisterHit(_damage, dir);
+			EnemyController* enemy = enemies_children[i]->GetComponent<EnemyController>();
+			if (enemy)
+			{
+				enemy->RegisterHit(_damage, dir);
+			}
 			return true;
 		}
 	}

--- a/Gameplay/BulletController.h
+++ b/Gameplay/BulletController.h
@@ -15,7 +15,7 @@ namespace Hachiko
         public:
             BulletController(GameObject* game_object);
             ~BulletController() override = default;
-
+            
             void OnAwake() override;
             void OnUpdate() override;
 

--- a/Gameplay/EnemyController.cpp
+++ b/Gameplay/EnemyController.cpp
@@ -212,5 +212,5 @@ void Hachiko::Scripting::EnemyController::MoveInNavmesh()
 void Hachiko::Scripting::EnemyController::DestroyEntity()
 {
 	game_object->SetActive(false);
-	RELEASE(game_object);
+	SceneManagement::Destroy(game_object);
 }

--- a/Source/src/Gameplay.cpp
+++ b/Source/src/Gameplay.cpp
@@ -118,7 +118,7 @@ Hachiko::GameObject* Hachiko::SceneManagement::FindInCurrentScene(
 
 HACHIKO_API void Hachiko::SceneManagement::Destroy(GameObject* game_object)
 {
-    delete game_object;
+    App->scene_manager->RemoveGameObject(game_object);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -241,16 +241,12 @@ Hachiko::Component* Hachiko::GameObject::CreateComponent(Component::Type type)
 
 void Hachiko::GameObject::SetActive(bool set_active)
 {
-    for (GameObject* child : children)
-    {
-        child->SetActive(set_active);
-    }
     if (!active && set_active)
     {
         Start();
     }
     active = set_active;
-
+    
     for (GameObject* child : children)
     {
         child->SetActive(set_active);

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -58,11 +58,6 @@ Hachiko::GameObject::~GameObject()
         parent->RemoveChild(this);
     }
 
-    if (scene_owner)
-    {
-        scene_owner->DestroyGameObject(this);
-    }
-
     for (GameObject* child : children)
     {
         child->parent = nullptr;
@@ -72,7 +67,6 @@ Hachiko::GameObject::~GameObject()
     {
         RELEASE(component);
     }
-    scene_owner = nullptr;
 }
 
 void Hachiko::GameObject::RemoveChild(GameObject* game_object)

--- a/Source/src/core/GameObject.h
+++ b/Source/src/core/GameObject.h
@@ -24,6 +24,8 @@ namespace Hachiko
     class HACHIKO_API GameObject final
     {
         friend class Component;
+        friend class Scene;
+        friend class ModuleSceneManager;
 
     public:
         GameObject(const char* name = "Unnamed", UID uid = UUID::GenerateUID());
@@ -34,8 +36,11 @@ namespace Hachiko
                    const float3& translation = float3::zero,
                    const Quat& rotation = Quat::identity,
                    const float3& scale = float3::one);
-        virtual ~GameObject();
 
+    private:
+        ~GameObject();
+
+    public:
         void SetNewParent(GameObject* new_parent);
 
         void AddComponent(Component* component);

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -49,14 +49,6 @@ void Hachiko::Scene::CleanScene()
     loaded = false;
 }
 
-void Hachiko::Scene::DestroyGameObject(GameObject* game_object)
-{
-    if (App->editor->GetSelectedGameObject() == game_object)
-    {
-        App->editor->SetSelectedGO(nullptr);
-    }
-}
-
 Hachiko::ComponentCamera* Hachiko::Scene::GetMainCamera() const
 {
     // This will return the first camera it comes across in the hierarchy in a 

--- a/Source/src/importers/ModelImporter.cpp
+++ b/Source/src/importers/ModelImporter.cpp
@@ -7,6 +7,7 @@
 
 #include "core/preferences/src/ResourcesPreferences.h"
 #include "modules/ModuleResources.h"
+#include "modules/ModuleSceneManager.h"
 #include "components/ComponentMeshRenderer.h"
 #include "components/ComponentAnimation.h"
 #include "components/ComponentTransform.h"
@@ -127,7 +128,7 @@ void Hachiko::ModelImporter::ImportModel(const char* path, const aiScene* scene,
 
     // Create prefab
     UID prefab_uid = prefab_importer.CreatePrefabAsset(filename.c_str(), model_root->children[0]);
-    delete model_root;
+    App->scene_manager->RemoveGameObject(model_root);
     meta[PREFAB_ID] = prefab_uid;
 
     for (unsigned i = 0; i < resource_ids.size(); ++i)

--- a/Source/src/modules/ModuleCamera.cpp
+++ b/Source/src/modules/ModuleCamera.cpp
@@ -61,7 +61,7 @@ bool Hachiko::ModuleCamera::CleanUp()
 
     camera_buffer.erase(camera_buffer.begin());
     camera_buffer.clear();
-    delete rendering_camera->GetGameObject();
+    App->scene_manager->RemoveGameObject(rendering_camera->GetGameObject());
     return true;
 }
 

--- a/Source/src/modules/ModuleEditor.cpp
+++ b/Source/src/modules/ModuleEditor.cpp
@@ -311,7 +311,9 @@ UpdateStatus Hachiko::ModuleEditor::FileMenu()
     if (ImGui::MenuItem(ICON_FA_PLUS "New"))
     {
         history.CleanUp();
-        App->scene_manager->CreateEmptyScene();
+        // Create new scene with engine stopped, passing id 0 does that
+        constexpr bool stop_scene = true;
+        App->scene_manager->ChangeSceneById(0, stop_scene);
         history.Init();
     }
     if (ImGui::MenuItem(ICON_FA_SAVE "Save", nullptr, false, true)) // TODO: Use internal timer to disable/enable

--- a/Source/src/modules/ModuleResources.cpp
+++ b/Source/src/modules/ModuleResources.cpp
@@ -224,7 +224,7 @@ void Hachiko::ModuleResources::LoadAsset(const std::string& path)
         case Resource::AssetType::SCENE:
             // Scene asset has to keep its scene id at the first position, navmesh is found inside scene serialization
             // It is also in resources array so it is reimported but no need to pass it here
-            App->scene_manager->LoadScene(meta_node[RESOURCES][0][RESOURCE_ID].as<UID>());
+            App->scene_manager->ChangeSceneById(meta_node[RESOURCES][0][RESOURCE_ID].as<UID>());
         }
     }
 }

--- a/Source/src/modules/ModuleResources.cpp
+++ b/Source/src/modules/ModuleResources.cpp
@@ -224,7 +224,9 @@ void Hachiko::ModuleResources::LoadAsset(const std::string& path)
         case Resource::AssetType::SCENE:
             // Scene asset has to keep its scene id at the first position, navmesh is found inside scene serialization
             // It is also in resources array so it is reimported but no need to pass it here
-            App->scene_manager->ChangeSceneById(meta_node[RESOURCES][0][RESOURCE_ID].as<UID>());
+            // Since when we load a scene asset we do it manually stop execution
+            constexpr bool stop_scene = true;
+            App->scene_manager->ChangeSceneById(meta_node[RESOURCES][0][RESOURCE_ID].as<UID>(), stop_scene);
         }
     }
 }

--- a/Source/src/modules/ModuleSceneManager.cpp
+++ b/Source/src/modules/ModuleSceneManager.cpp
@@ -93,16 +93,7 @@ void Hachiko::ModuleSceneManager::AttemptSceneStop()
 {
     if (GameTimer::running)
     {
-        Event game_state(Event::Type::GAME_STATE);
-        game_state.SetEventData<GameStateEventPayload>(GameStateEventPayload::State::STOPPED);
-        App->event->Publish(game_state);
-
-        main_scene->SetCullingCamera(App->camera->GetEditorCamera());
-        App->camera->SetRenderingCamera(App->camera->GetEditorCamera());
-        main_scene->Stop();
-
-        GameTimer::Stop();
-
+        StopScene();
         ReloadScene();
     }
 }
@@ -223,6 +214,18 @@ void Hachiko::ModuleSceneManager::CreateEmptyScene(const char* name)
     SetSceneResource(scene_importer.CreateSceneResource(main_scene));
 }
 
+void Hachiko::ModuleSceneManager::StopScene()
+{
+    Event game_state(Event::Type::GAME_STATE);
+    game_state.SetEventData<GameStateEventPayload>(GameStateEventPayload::State::STOPPED);
+    App->event->Publish(game_state);
+
+    App->camera->SetRenderingCamera(App->camera->GetEditorCamera());
+    main_scene->SetCullingCamera(App->camera->GetEditorCamera());
+    main_scene->Stop();
+    GameTimer::Stop();
+}
+
 void Hachiko::ModuleSceneManager::LoadScene(UID new_scene_id)
 {
     ResourceScene* scene_resource = static_cast<ResourceScene*>(App->resources->GetResource(Resource::Type::SCENE, new_scene_id));
@@ -263,10 +266,14 @@ Hachiko::GameObject* Hachiko::ModuleSceneManager::BoundingRaycast(const float3& 
     return main_scene->Raycast(origin, destination);
 }
 
-void Hachiko::ModuleSceneManager::ChangeSceneById(UID new_scene_id)
+void Hachiko::ModuleSceneManager::ChangeSceneById(UID new_scene_id, bool stop_scene)
 {
     scene_change_requested = true;
     scene_to_load_id = new_scene_id;
+    if (stop_scene)
+    {
+        StopScene();
+    }
 }
 
 void Hachiko::ModuleSceneManager::ReloadScene()

--- a/Source/src/modules/ModuleSceneManager.h
+++ b/Source/src/modules/ModuleSceneManager.h
@@ -13,6 +13,7 @@ namespace Hachiko
 
     class ModuleSceneManager final : public Module
     {
+        friend class ModuleDebugMode;
     public:
         ModuleSceneManager() = default;
         ~ModuleSceneManager() override = default;
@@ -51,11 +52,8 @@ namespace Hachiko
             return main_scene;
         }
 
-        void CreateEmptyScene(const char* name = nullptr);
-        void ChangeSceneById(UID new_scene_id);
-        void ReloadScene();
-
-                
+        void ChangeSceneById(UID new_scene_id, bool stop_scene = false);
+        
         void SaveScene(const char* file_path = nullptr);
 
         GameObject* Raycast(const float3& origin, const float3& destination);
@@ -64,9 +62,13 @@ namespace Hachiko
         void OptionsMenu();
 
     private:
+        void StopScene();
         void LoadScene(UID new_scene_id);
         void LoadScene(ResourceScene* scene, bool keep_navmesh = false);
         void ChangeMainScene(Scene* new_scene);
+        void CreateEmptyScene(const char* name = nullptr);
+        void ReloadScene();
+
         // Deletes current resource it it doesnt come from resource manager (for now assume it when id 0)
         void SetSceneResource(ResourceScene* scene);
         void RefreshSceneResource();

--- a/Source/src/modules/ModuleSceneManager.h
+++ b/Source/src/modules/ModuleSceneManager.h
@@ -26,7 +26,10 @@ namespace Hachiko
         bool IsScenePlaying();
         
         UpdateStatus Update(float delta) override;
+        UpdateStatus PostUpdate(float delta) override;
         bool CleanUp() override;
+
+        void RemoveGameObject(GameObject* go);
 
         GameObject* GetRoot()
         {
@@ -49,19 +52,19 @@ namespace Hachiko
         }
 
         void CreateEmptyScene(const char* name = nullptr);
+        void ChangeSceneById(UID new_scene_id);
+        void ReloadScene();
 
-        void LoadScene(UID new_scene_id);
+                
         void SaveScene(const char* file_path = nullptr);
 
         GameObject* Raycast(const float3& origin, const float3& destination);
         GameObject* BoundingRaycast(const float3& origin, const float3& destination);
-        void ChangeSceneById(UID new_scene_id);
-
-        void ReloadScene();
 
         void OptionsMenu();
 
     private:
+        void LoadScene(UID new_scene_id);
         void LoadScene(ResourceScene* scene, bool keep_navmesh = false);
         void ChangeMainScene(Scene* new_scene);
         // Deletes current resource it it doesnt come from resource manager (for now assume it when id 0)
@@ -71,10 +74,13 @@ namespace Hachiko
         ResourcesPreferences* preferences = nullptr;
 
 
-        bool scene_ready_to_load = false;
+        bool scene_change_requested = false;
+        bool scene_reload_requested = false;
+        UID scene_to_load_id;
+        std::vector<GameObject*> to_remove;
+
         bool scene_autosave = false;
         ResourceScene* scene_resource;
         ResourceNavMesh* navmesh_resource;
-        UID scene_to_load_id;
     };
 } // namespace Hachiko

--- a/Source/src/ui/WindowHierarchy.cpp
+++ b/Source/src/ui/WindowHierarchy.cpp
@@ -24,12 +24,6 @@ void Hachiko::WindowHierarchy::Update()
     ImGui::End();
 }
 
-void Hachiko::WindowHierarchy::CleanUp()
-{
-    dragged_object = nullptr;
-    delete dragged_object;
-}
-
 void Hachiko::WindowHierarchy::DrawHierarchyTree(const GameObject* game_object)
 {
     for (int i = 0; i < game_object->children.size(); ++i)
@@ -145,7 +139,7 @@ bool Hachiko::WindowHierarchy::DrawGameObject(GameObject* game_object, bool stop
         }
         if (ImGui::MenuItem("Delete Game Object"))
         {
-            RELEASE(game_object);
+            App->scene_manager->RemoveGameObject(game_object);
             dragged_object = nullptr;
             ImGui::CloseCurrentPopup();
             App->event->Publish(Event::Type::CREATE_EDITOR_HISTORY_ENTRY);

--- a/Source/src/ui/WindowHierarchy.h
+++ b/Source/src/ui/WindowHierarchy.h
@@ -12,7 +12,6 @@ namespace Hachiko
         ~WindowHierarchy() override;
 
         void Update() override;
-        void CleanUp() override;
 
     private:
         void DrawHierarchyTree(const GameObject* game_object);


### PR DESCRIPTION
**Changes**
- Gameobjects are destroyed on scene manager postupdate
- Gameobjects can only be deleted by friend classes, you have to use scene manager otherwise
- Scene is changed on post update when called by an outside module. (An exception is create empty scene for now but probably it also should to be consistent
- Fixed bullet controller to not derreference enemy controller if it doesnt exist

I tried the bullet issue faking the quadtree fix (calling refresh actively) and those changes in combination seem to stop the crashes entirely, I will have to test more.