### PR TITLE
Ignore models in large folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,3 +384,4 @@ Game/Hachiko*
 Game/*.scene
 Game/library/*
 Game/settings/he.cfg
+Game/assets/models/large/*.fbx


### PR DESCRIPTION
Stop tracking .fbx files inside large folder