### PR TITLE
Traveling camera script with prefab

### DIFF
--- a/Game/assets/prefabs/TravelingCamera.prefab
+++ b/Game/assets/prefabs/TravelingCamera.prefab
@@ -1,0 +1,96 @@
+prefab_name: TravelingCamera
+name: TravelingCamera
+enabled: true
+component:
+  - !<transform>
+    type: 1
+    enabled: true
+    position: [0, 0, 0]
+    rotation: [0, 0, 0, 1]
+    scale: [1, 1, 1]
+  - !<script>
+    type: 15
+    enabled: true
+    class_name: DynamicCamera
+    "'_speed@float'": 5
+child:
+  - name: TravelingCamera
+    enabled: true
+    component:
+      - !<transform>
+        type: 1
+        enabled: true
+        position: [-9.586, 17.96, -34.31]
+        rotation: [0.2303, 0.1818, -0.0439, 0.955]
+        scale: [1, 1, 1]
+      - !<camera>
+        type: 4
+        enabled: true
+        frustum:
+          near_distance: 0.1
+          far_distance: 1000
+          fov: 65
+          position: [-9.586, 17.96, -34.31]
+          front: [0.327, -0.4558, 0.8278]
+          up: [0.1676, 0.8901, 0.4239]
+          pinned_camera: [0, 0, 0]
+  - name: Shot1
+    enabled: true
+    component:
+      - !<transform>
+        type: 1
+        enabled: true
+        position: [-14.47, 18.4, -36.67]
+        rotation: [0.2623, 0.1995, -0.0555, 0.9425]
+        scale: [1, 1, 1]
+      - !<camera>
+        type: 4
+        enabled: true
+        frustum:
+          near_distance: 0.1
+          far_distance: 1000
+          fov: 65
+          position: [-14.47, 18.4, -36.67]
+          front: [0.3469, -0.5166, 0.7828]
+          up: [0.2093, 0.8562, 0.4723]
+          pinned_camera: [0, 0, 0]
+  - name: Shot2
+    enabled: true
+    component:
+      - !<transform>
+        type: 1
+        enabled: true
+        position: [12.05, -1.914, 34.95]
+        rotation: [0.0064, 0.9826, 0.0343, -0.1822]
+        scale: [0.9996, 1, 0.9996]
+      - !<camera>
+        type: 4
+        enabled: true
+        frustum:
+          near_distance: 0.1
+          far_distance: 1000
+          fov: 65
+          position: [12.05, -1.914, 34.95]
+          front: [-0.3577, 0.0697, -0.9312]
+          up: [0.0251, 0.9976, 0.0651]
+          pinned_camera: [0, 0, 0]
+  - name: Shot3
+    enabled: true
+    component:
+      - !<transform>
+        type: 1
+        enabled: true
+        position: [3.093, 40.8, 9.044]
+        rotation: [0.0181, 0.7886, -0.6142, 0.0233]
+        scale: [1, 1, 1]
+      - !<camera>
+        type: 4
+        enabled: true
+        frustum:
+          near_distance: 0.1
+          far_distance: 1000
+          fov: 65
+          position: [3.093, 40.8, 9.044]
+          front: [0.0145, -0.9696, -0.2444]
+          up: [0.0572, 0.2449, -0.9679]
+          pinned_camera: [0, 0, 0]

--- a/Game/assets/prefabs/TravelingCamera.prefab.meta
+++ b/Game/assets/prefabs/TravelingCamera.prefab.meta
@@ -1,0 +1,5 @@
+asset_hash: 2321592176947356184
+resources:
+  - resource_id: 4638980655090640082
+    resource_type: 13
+    resource_hash: 2321592176947356184

--- a/Game/assets/scenes/CameraTest.scene
+++ b/Game/assets/scenes/CameraTest.scene
@@ -1,0 +1,257 @@
+scene_name: CameraTest
+navmesh_id: 12909483272333323460
+skybox:
+  right_cube_id: 0
+  left_cube_id: 0
+  top_cube_id: 0
+  bottom_cube_id: 0
+  center_cube_id: 0
+  back_cube_id: 0
+root_id: 9182050610880223868
+child:
+  - id: 1055489386756321936
+    name: BakerHouse
+    enabled: true
+    component:
+      - !<transform>
+        id: 751750478711048629
+        type: 1
+        enabled: true
+        position: [0, 0, 0]
+        rotation: [0.7752, 0, 0, 0.6317]
+        scale: [1, 1, 1]
+    child:
+      - id: 15544913473548298170
+        name: Chimney
+        enabled: true
+        component:
+          - !<transform>
+            id: 12542103125410466808
+            type: 1
+            enabled: true
+            position: [0, 0, 0]
+            rotation: [-0.7071, 0, 0, 0.7071]
+            scale: [100, 100, 100]
+          - !<mesh_renderer>
+            id: 12364271612535068181
+            type: 2
+            enabled: true
+            mesh_id: 7544551443759936381
+            navigable: false
+            visible: true
+            material_id: 7765775954106249835
+      - id: 16738082121615900831
+        name: Baker_house
+        enabled: true
+        component:
+          - !<transform>
+            id: 2436179244814941443
+            type: 1
+            enabled: true
+            position: [0, 0, 0]
+            rotation: [-0.7071, 0, 0, 0.7071]
+            scale: [100, 100, 100]
+          - !<mesh_renderer>
+            id: 17887169278521849379
+            type: 2
+            enabled: true
+            mesh_id: 3581704332068092856
+            navigable: false
+            visible: true
+            material_id: 7765775954106249835
+  - id: 13350498086885454940
+    name: parasiteConsumable
+    enabled: true
+    component:
+      - !<transform>
+        id: 7136538383632107248
+        type: 1
+        enabled: true
+        position: [30.41, 0, 0]
+        rotation: [0, 0, 0, 1]
+        scale: [5.41, 5.41, 5.41]
+    child:
+      - id: 9220185200726337874
+        name: PM3D_Sphere124
+        enabled: true
+        component:
+          - !<transform>
+            id: 7995038291637432264
+            type: 1
+            enabled: true
+            position: [0, 0, 0]
+            rotation: [0, 0, 0, 1]
+            scale: [1, 1, 1]
+          - !<mesh_renderer>
+            id: 2756947570470438984
+            type: 2
+            enabled: true
+            mesh_id: 8953689370358422284
+            navigable: false
+            visible: true
+            material_id: 3003390711770185065
+  - id: 12120146660273666500
+    name: cube
+    enabled: true
+    component:
+      - !<transform>
+        id: 15004739654416105115
+        type: 1
+        enabled: true
+        position: [0, -9.672, 8.454]
+        rotation: [0, 0, 0, 1]
+        scale: [17, 5.689, 14.19]
+    child:
+      - id: 8631871374187053909
+        name: Box001
+        enabled: true
+        component:
+          - !<transform>
+            id: 17107580077693933336
+            type: 1
+            enabled: true
+            position: [0, 0, 0]
+            rotation: [-0.7071, 0, 0, 0.7071]
+            scale: [1, 1, 1]
+          - !<mesh_renderer>
+            id: 10868537992710722192
+            type: 2
+            enabled: true
+            mesh_id: 1654487118907036717
+            navigable: false
+            visible: true
+            material_id: 6750369022920963075
+  - id: 16779925319465180152
+    name: TravelingCamera
+    enabled: true
+    component:
+      - !<transform>
+        id: 518598590117120254
+        type: 1
+        enabled: true
+        position: [0, 0, 0]
+        rotation: [0, 0, 0, 1]
+        scale: [1, 1, 1]
+      - !<script>
+        id: 11555905852396441997
+        type: 15
+        enabled: true
+        class_name: DynamicCamera
+        "'_speed@float'": 5
+        "'_camera_go@GameObject*'": 268960208217008997
+    child:
+      - id: 13476396489563837884
+        name: TravelingCamera
+        enabled: true
+        component:
+          - !<transform>
+            id: 9879775521114771569
+            type: 1
+            enabled: true
+            position: [-9.586, 17.96, -34.31]
+            rotation: [0.2303, 0.1818, -0.0439, 0.955]
+            scale: [1, 1, 1]
+          - !<camera>
+            id: 10811947637702218249
+            type: 4
+            enabled: true
+            frustum:
+              near_distance: 0.1
+              far_distance: 1000
+              fov: 65
+              position: [-9.586, 17.96, -34.31]
+              front: [0.3271, -0.4558, 0.8278]
+              up: [0.1675, 0.8901, 0.424]
+              pinned_camera: [0, 0, 0]
+      - id: 4264423907877998756
+        name: Shot1
+        enabled: true
+        component:
+          - !<transform>
+            id: 16974824428425792147
+            type: 1
+            enabled: true
+            position: [-14.47, 18.4, -36.67]
+            rotation: [0.2623, 0.1995, -0.0555, 0.9425]
+            scale: [1, 1, 1]
+          - !<camera>
+            id: 259644826317594066
+            type: 4
+            enabled: true
+            frustum:
+              near_distance: 0.1
+              far_distance: 1000
+              fov: 65
+              position: [-14.47, 18.4, -36.67]
+              front: [0.3469, -0.5166, 0.7828]
+              up: [0.2093, 0.8562, 0.4723]
+              pinned_camera: [0, 0, 0]
+      - id: 7949312015517518787
+        name: Shot2
+        enabled: true
+        component:
+          - !<transform>
+            id: 5915195892753825913
+            type: 1
+            enabled: true
+            position: [12.05, -1.914, 34.95]
+            rotation: [0.0064, 0.9826, 0.0343, -0.1822]
+            scale: [1, 1, 1]
+          - !<camera>
+            id: 14311879847708606012
+            type: 4
+            enabled: true
+            frustum:
+              near_distance: 0.1
+              far_distance: 1000
+              fov: 65
+              position: [12.05, -1.914, 34.95]
+              front: [-0.3576, 0.0697, -0.9313]
+              up: [0.025, 0.9976, 0.0651]
+              pinned_camera: [0, 0, 0]
+      - id: 16672946159436967335
+        name: Shot3
+        enabled: true
+        component:
+          - !<transform>
+            id: 1244887640921362443
+            type: 1
+            enabled: true
+            position: [3.093, 40.8, 9.044]
+            rotation: [0.0181, 0.7886, -0.6142, 0.0233]
+            scale: [1, 1, 1]
+          - !<camera>
+            id: 17366225264641734016
+            type: 4
+            enabled: true
+            frustum:
+              near_distance: 0.1
+              far_distance: 1000
+              fov: 65
+              position: [3.093, 40.8, 9.044]
+              front: [0.0144, -0.9696, -0.2444]
+              up: [0.0572, 0.2448, -0.9679]
+              pinned_camera: [0, 0, 0]
+  - id: 268960208217008997
+    name: Main Cam
+    enabled: true
+    component:
+      - !<transform>
+        id: 1031955147775149251
+        type: 1
+        enabled: true
+        position: [-31.86, 0, -27.31]
+        rotation: [0, 0.3781, 0, 0.9258]
+        scale: [1, 1, 1]
+      - !<camera>
+        id: 8813547896911725590
+        type: 4
+        enabled: true
+        frustum:
+          near_distance: 0.1
+          far_distance: 1000
+          fov: 65
+          position: [-31.86, 0, -27.31]
+          front: [0.7001, 0, 0.7141]
+          up: [0, 1, 0]
+          pinned_camera: [0, 0, 0]

--- a/Game/assets/scenes/CameraTest.scene.meta
+++ b/Game/assets/scenes/CameraTest.scene.meta
@@ -1,0 +1,8 @@
+asset_hash: 17215593868484253066
+resources:
+  - resource_id: 12328717362222769603
+    resource_type: 4
+    resource_hash: 17215593868484253066
+  - resource_id: 12909483272333323460
+    resource_type: 12
+    resource_hash: 10875453883105892925

--- a/Gameplay/misc/DynamicCamera.cpp
+++ b/Gameplay/misc/DynamicCamera.cpp
@@ -3,41 +3,95 @@
 
 Hachiko::Scripting::DynamicCamera::DynamicCamera(GameObject* game_object)
 	: Script(game_object, "DynamicCamera")
-	, _start_point(math::float3::zero)
-	, _end_point(math::float3::zero)
 	, _speed(0.0f)
-	, _lerp_position(0.0f)
 {
+}
+
+void Hachiko::Scripting::DynamicCamera::SetCurrentShot(unsigned target_idx)
+{
+	if (target_idx >= _camera_positions.size()) return;
+
+	ComponentTransform* target = _camera_positions[_current_target]->GetTransform();
+	_camera_transform->SetGlobalPosition(target->GetGlobalPosition());
+	_camera_transform->SetGlobalRotation(target->GetGlobalRotation());
 }
 
 void Hachiko::Scripting::DynamicCamera::OnAwake()
 {
-	_start_point = game_object->GetTransform()->GetGlobalPosition();
-	_end_point = math::float3(-10.0f, 3.0f, -4.0f);
-	_speed = 5.0f;
-	_lerp_position = 0.0f;
-}
+	_camera_go = game_object->children[0];
+	_camera = _camera_go->GetComponent<ComponentCamera>();
+	// Use all children except first as camera positions
+	_camera_positions = std::vector<GameObject*>(game_object->children.begin() + 1, game_object->children.end());
+	
+	// Make all cameras inactive
+	for (GameObject* _camera_position : _camera_positions)
+	{
+		_camera_position->SetActive(false);
+	}
+	// Camera 0 is the traveling camera
+	_camera_transform = _camera_go->GetTransform();
+	_camera = _camera_go->GetComponent<ComponentCamera>();
 
-void Hachiko::Scripting::DynamicCamera::OnStart()
-{
+	SetCurrentShot(0);
+	GetNextTargetShot();
+	StartCameraTravel();
 }
 
 void Hachiko::Scripting::DynamicCamera::OnUpdate()
 {
+	if (!_playing) return;
+	
+	_transition_progress += Time::DeltaTime() / _transition_duration;
+
 	ComponentTransform* transform = game_object->GetTransform();
-	
-	float delta_time = Time::DeltaTime();
-	float distance = math::Distance(_start_point, _end_point);
 
-	_lerp_position += _speed * delta_time;
-	
-	if (_lerp_position > distance)
+	if (_transition_progress >= 1.f)
 	{
-		_lerp_position = 0.0f;
+		_transition_progress = 1.f;
+		MoveToCurrentTargetShot();
+		GetNextTargetShot();
+		return;
 	}
+	MoveToCurrentTargetShot();
+}
 
-	math::float3 lerped_position = math::float3::Lerp(_start_point, _end_point,
-		_lerp_position / distance);
+void Hachiko::Scripting::DynamicCamera::MoveToCurrentTargetShot()
+{
+	ComponentTransform* target = _camera_positions[_current_target]->GetTransform();
+	_camera_transform->SetGlobalPosition(float3::Lerp(_start_pos, target->GetGlobalPosition(), _transition_progress));
+	_camera_transform->SetGlobalRotation(Quat::Lerp(_start_rot, target->GetGlobalRotation(), _transition_progress));
+}
 
-	transform->SetGlobalPosition(lerped_position);
+void Hachiko::Scripting::DynamicCamera::GetNextTargetShot()
+{
+	++_current_target;
+	if (_camera_positions.empty())
+	{
+		_current_target = 0;
+		_playing = false;
+		return;
+	}
+	if (_current_target >= _camera_positions.size())
+	{
+		_current_target = 1;
+		_playing = false;
+		return;
+	}
+	SetTravelTarget(_current_target);
+}
+
+void Hachiko::Scripting::DynamicCamera::SetTravelTarget(unsigned target_idx)
+{
+	_current_target = target_idx;
+	ComputeTransition(_current_target);
+}
+
+void Hachiko::Scripting::DynamicCamera::ComputeTransition(unsigned target_idx)
+{
+	ComponentTransform* target = _camera_positions[target_idx]->GetTransform();
+	_start_pos = _camera_transform->GetGlobalPosition();
+	_start_rot = _camera_transform->GetGlobalRotation();
+	float distance = _camera_transform->GetGlobalPosition().Distance(target->GetGlobalPosition());
+	_transition_progress = 0.f;
+	_transition_duration = distance / _speed;
 }

--- a/Gameplay/misc/DynamicCamera.h
+++ b/Gameplay/misc/DynamicCamera.h
@@ -15,15 +15,29 @@ public:
 	DynamicCamera(GameObject* game_object);
 	~DynamicCamera() override = default;
 
+	void StartCameraTravel() { _playing = true; }
+	void StopCameraTravel() { _playing = false; }
+	void SetCurrentShot(unsigned target_idx);
+
 	void OnAwake() override;
-	void OnStart() override;
 	void OnUpdate() override;
 
 private:
-	SERIALIZE_FIELD(math::float3, _start_point);
-	SERIALIZE_FIELD(math::float3, _end_point);
+	void MoveToCurrentTargetShot();
+	void GetNextTargetShot();
+	void SetTravelTarget(unsigned target_idx);
+	void ComputeTransition(unsigned target_idx);
 	SERIALIZE_FIELD(float, _speed);
-	SERIALIZE_FIELD(float, _lerp_position);
+	GameObject* _camera_go = nullptr;
+	std::vector< GameObject*> _camera_positions;
+	ComponentTransform* _camera_transform;
+	ComponentCamera* _camera;
+	unsigned _current_target = 0;
+	float _transition_progress = 0.f;
+	float _transition_duration = 0.f;
+	float3 _start_pos = float3::zero;
+	Quat _start_rot{};
+	bool _playing = false;
 };
 } // namespace Scripting
 } // namespace Hachiko

--- a/Source/src/modules/ModuleCamera.cpp
+++ b/Source/src/modules/ModuleCamera.cpp
@@ -157,6 +157,10 @@ void Hachiko::ModuleCamera::ToggleCamera()
         camera_idx = 0;
     }
     SetRenderingCamera(camera_buffer[camera_idx]);
+    if (!rendering_camera->GetGameObject()->IsActive())
+    {
+        ToggleCamera();
+    }
 }
 
 void Hachiko::ModuleCamera::SetRenderingCamera(ComponentCamera* camera)


### PR DESCRIPTION
**How it works**
- Parent contains script that manages its children, children 0 is the camera to be moved, other children are the target positions where the camera will move.
- It uses constant speed to lerp between the different camera shots
- All the shots gameobjects are disabled on script start since during gameplay we will only use their transforms
![image](https://user-images.githubusercontent.com/28431584/175998707-f43350e9-9c15-4b50-bf0a-c2f5dba4fe91.png)
![image](https://user-images.githubusercontent.com/28431584/175998813-a0b12f2b-7ad6-4ba3-abd9-23c950e0a68d.png)


**How to use**
- Add its prefab and manage shot children objects to define the desired travel
- Since each children has a camera component it is easy to set the shot up using the preview feature
- For now it starts playing on awake since it is not wired to any game logic

I will remove test scene before merging, remember u can switch between cameras while playing on editor mode using F3