### PR TITLE
Feature/UI tint color

### DIFF
--- a/Game/assets/prefabs/generated/1609652816773405397.prefab
+++ b/Game/assets/prefabs/generated/1609652816773405397.prefab
@@ -59,6 +59,7 @@ child:
                     navigable: false
                     visible: true
                     material_id: 12924252210591909690
+                    tint_color: [1, 1, 1, 1]
   - name: mixamorig:Hips
     enabled: true
     component:

--- a/Game/assets/prefabs/generated/1609652816773405397.prefab.meta
+++ b/Game/assets/prefabs/generated/1609652816773405397.prefab.meta
@@ -1,5 +1,5 @@
-asset_hash: 362496928169553638
+asset_hash: 15037240585445167581
 resources:
   - resource_id: 1609652816773405397
     resource_type: 13
-    resource_hash: 362496928169553638
+    resource_hash: 15037240585445167581

--- a/Game/shaders/fragment_ui.glsl
+++ b/Game/shaders/fragment_ui.glsl
@@ -25,6 +25,6 @@ void main()
     {
         float u = (tex_coord.x + animation_index.x) * factor.x;
         float v = (tex_coord.y + animation_index.y) * factor.y;
-        color = texture2D(diffuse,  vec2(u, v));
+        color *= texture2D(diffuse,  vec2(u, v));
     }
 }

--- a/Source/src/components/ComponentImage.cpp
+++ b/Source/src/components/ComponentImage.cpp
@@ -60,11 +60,9 @@ void Hachiko::ComponentImage::DrawGui()
             ImGuiFileDialog::Instance()->Close();
         }
 
-        if (!use_image || !image)
-        {
-            ImGuiUtils::CompactColorPicker("Image Color", color.ptr());
-        }
-        else
+        ImGui::ColorEdit4("Image Color", &color[0]);
+
+        if (use_image)
         {
             if (ImGui::Checkbox("Is tiled", &is_tiled))
             {
@@ -123,7 +121,7 @@ void Hachiko::ComponentImage::DrawGui()
 
         if (!use_hover_image || !hover_image)
         {
-            ImGuiUtils::CompactColorPicker("Hover Color", hover_color.ptr());
+            ImGui::ColorEdit4("Hover Color", &hover_color[0]);
         }
 
         ImGui::Text("Image Loaded %d", image != nullptr);
@@ -211,7 +209,10 @@ void Hachiko::ComponentImage::Save(YAML::Node& node) const
     node[USE_HOVER_IMAGE] = use_hover_image;
     node[IMAGE_COLOR] = color;
     node[IMAGE_HOVER_COLOR] = hover_color;
-    node["fill_window"] = fill_window;
+    node[IMAGE_TILED] = is_tiled;
+    node[IMAGE_X_TILES] = x_tiles;
+    node[IMAGE_Y_TILES] = y_tiles;
+    node[IMAGE_TILES_PER_SEC] = frames_per_second;
 }
 
 void Hachiko::ComponentImage::Load(const YAML::Node& node)
@@ -228,6 +229,13 @@ void Hachiko::ComponentImage::Load(const YAML::Node& node)
     color = node[IMAGE_COLOR].as<float4>();
     hover_color = node[IMAGE_HOVER_COLOR].as<float4>();
     fill_window = node["fill_window"].IsDefined() ? node["fill_window"].as<bool>() : false;
+
+    is_tiled = node[IMAGE_TILED].IsDefined() ? node[IMAGE_TILED].as<bool>() : false;
+    x_tiles = node[IMAGE_X_TILES].IsDefined() ? node[IMAGE_X_TILES].as<int>() : 1;
+    y_tiles = node[IMAGE_Y_TILES].IsDefined() ? node[IMAGE_Y_TILES].as<int>() : 1;
+    frames_per_second = node[IMAGE_TILES_PER_SEC].IsDefined() ? node[IMAGE_TILES_PER_SEC].as<int>() : 1;
+    factor = float2(1.0f / x_tiles, 1.0f / y_tiles);
+    time_per_frame = 1.0f / frames_per_second;
 }
 
 void Hachiko::ComponentImage::UpdateSize()

--- a/Source/src/components/ComponentImage.cpp
+++ b/Source/src/components/ComponentImage.cpp
@@ -31,7 +31,6 @@ void Hachiko::ComponentImage::DrawGui()
     {   
 
         ImGui::Text("Normal Image");
-        ImGui::Checkbox("Use Image", &use_image);
 
         const std::string title = "Select Image";
         if (ImGui::Button(title.c_str()))
@@ -44,6 +43,24 @@ void Hachiko::ComponentImage::DrawGui()
                                                     nullptr,
                                                     ImGuiFileDialogFlags_DontShowHiddenFiles | ImGuiFileDialogFlags_DisableCreateDirectoryButton | ImGuiFileDialogFlags_HideColumnType
                                                         | ImGuiFileDialogFlags_HideColumnDate);
+        }
+        ImGui::SameLine();
+        if (image != nullptr)
+        {
+            if (ImGui::Button("X##image"))
+            {
+                App->resources->ReleaseResource(image);
+                image = nullptr;
+            }
+            else
+            {
+                ImGui::SameLine();
+                ImGui::Text(StringUtils::Concat("Selected: ", image->path).c_str());
+            }
+        }
+        else
+        {
+            ImGui::Text("None");
         }
 
         if (ImGuiFileDialog::Instance()->Display(title.c_str()))
@@ -62,7 +79,7 @@ void Hachiko::ComponentImage::DrawGui()
 
         ImGui::ColorEdit4("Image Color", &color[0]);
 
-        if (use_image)
+        if (image != nullptr)
         {
             if (ImGui::Checkbox("Is tiled", &is_tiled))
             {
@@ -104,6 +121,24 @@ void Hachiko::ComponentImage::DrawGui()
                                                     ImGuiFileDialogFlags_DontShowHiddenFiles | ImGuiFileDialogFlags_DisableCreateDirectoryButton | ImGuiFileDialogFlags_HideColumnType
                                                         | ImGuiFileDialogFlags_HideColumnDate);
         }
+        ImGui::SameLine();
+        if (hover_image != nullptr)
+        {
+            if (ImGui::Button("X##hover_image"))
+            {
+                App->resources->ReleaseResource(hover_image);
+                hover_image = nullptr;
+            }
+            else
+            {
+                ImGui::SameLine();
+                ImGui::Text(StringUtils::Concat("Selected: ", hover_image->path).c_str());
+            }
+        }
+        else
+        {
+            ImGui::Text("None");
+        }
 
         if (ImGuiFileDialog::Instance()->Display(hover_title.c_str()))
         {
@@ -119,13 +154,7 @@ void Hachiko::ComponentImage::DrawGui()
             ImGuiFileDialog::Instance()->Close();
         }
 
-        if (!use_hover_image || !hover_image)
-        {
-            ImGui::ColorEdit4("Hover Color", &hover_color[0]);
-        }
-
-        ImGui::Text("Image Loaded %d", image != nullptr);
-        ImGui::Text("Hover Image Loaded %d", hover_image != nullptr);
+        ImGui::ColorEdit4("Hover Color", &hover_color[0]);
 	}
     ImGui::PopID();
 }
@@ -141,7 +170,6 @@ void Hachiko::ComponentImage::Draw(ComponentTransform2D* transform, Program* pro
     program->BindUniformFloat4x4("model", transform->GetGlobalScaledTransform().ptr());
     const ResourceTexture* img_to_draw = image;
     const float4* render_color = &color;
-    bool render_img = use_image;    
 
     ComponentButton* button = game_object->GetComponent<ComponentButton>();
 
@@ -149,10 +177,9 @@ void Hachiko::ComponentImage::Draw(ComponentTransform2D* transform, Program* pro
     {
         img_to_draw = hover_image;
         render_color = &hover_color;
-        render_img = use_hover_image;
     }
 
-    program->BindUniformBool("diffuse_flag", img_to_draw && render_img);
+    program->BindUniformBool("diffuse_flag", img_to_draw != nullptr);
     program->BindUniformFloat4("img_color", render_color->ptr());
     ModuleTexture::Bind(img_to_draw? img_to_draw->GetImageId(): 0, static_cast<int>(Hachiko::ModuleProgram::TextureSlots::DIFFUSE));
 
@@ -172,7 +199,7 @@ void Hachiko::ComponentImage::Update()
     {
         UpdateSize();
     }
-    if (use_image)
+    if (image != nullptr)
     {
         if (is_tiled)
         {
@@ -205,8 +232,6 @@ void Hachiko::ComponentImage::Save(YAML::Node& node) const
     node.SetTag("image");
     node[IMAGE_IMAGE_ID] = image ? image->GetID() : 0;
     node[IMAGE_HOVER_IMAGE_ID] = hover_image ? hover_image->GetID() : 0;
-    node[USE_IMAGE] = use_image;
-    node[USE_HOVER_IMAGE] = use_hover_image;
     node[IMAGE_COLOR] = color;
     node[IMAGE_HOVER_COLOR] = hover_color;
     node[IMAGE_TILED] = is_tiled;
@@ -218,14 +243,8 @@ void Hachiko::ComponentImage::Save(YAML::Node& node) const
 void Hachiko::ComponentImage::Load(const YAML::Node& node)
 {
     constexpr bool is_hover_image = true;
-    if (node[USE_IMAGE].IsDefined())
-    {
-        use_image = node[USE_IMAGE].as<bool>();    
-    }
     LoadImageResource(node[IMAGE_IMAGE_ID].as<UID>(), !is_hover_image);
     LoadImageResource(node[IMAGE_HOVER_IMAGE_ID].as<UID>(), is_hover_image);
-    use_image = node[USE_IMAGE].as<bool>();
-    use_hover_image = node[USE_HOVER_IMAGE].as<bool>();
     color = node[IMAGE_COLOR].as<float4>();
     hover_color = node[IMAGE_HOVER_COLOR].as<float4>();
     fill_window = node["fill_window"].IsDefined() ? node["fill_window"].as<bool>() : false;

--- a/Source/src/components/ComponentImage.h
+++ b/Source/src/components/ComponentImage.h
@@ -54,8 +54,6 @@ namespace Hachiko
 
         float4 color = float4::one;
         float4 hover_color = float4::one;
-        bool use_image = false;
-        bool use_hover_image = false;
         bool fill_window = false;
 
         // TODO: Make properly after bs

--- a/Source/src/components/ComponentMeshRenderer.cpp
+++ b/Source/src/components/ComponentMeshRenderer.cpp
@@ -236,6 +236,7 @@ void Hachiko::ComponentMeshRenderer::Save(YAML::Node& node) const
     {
         node[RENDERER_MATERIAL_ID] = 0;
     }
+    node[RENDERER_TINT_COLOR] = tint_color;
 }
 
 void Hachiko::ComponentMeshRenderer::Load(const YAML::Node& node)
@@ -253,6 +254,7 @@ void Hachiko::ComponentMeshRenderer::Load(const YAML::Node& node)
     {
         LoadMaterial(material_id);
     }
+    tint_color = node[RENDERER_TINT_COLOR].IsDefined() ? node[RENDERER_TINT_COLOR].as<float4>() : float4::one;
 }
 
 Hachiko::GameObject* GetRoot(Hachiko::GameObject* posible_root) 

--- a/Source/src/core/preferences/src/EditorPreferences.cpp
+++ b/Source/src/core/preferences/src/EditorPreferences.cpp
@@ -68,6 +68,11 @@ void EditorPreferences::LoadConfigurationData(const YAML::Node& node)
         {
             draw_navmesh = it->second.as<bool>();
         }
+
+        if (it->first.as<std::string>()._Equal(UNDO_REDO_ACTIVE))
+        {
+            undo_redo_active = it->second.as<bool>();
+        }
     }
 }
 
@@ -83,4 +88,5 @@ void EditorPreferences::SaveConfigurationData(YAML::Node& node)
     node[group_name][DISPLAY_SKYBOX] = draw_skybox;
     node[group_name][DISPLAY_QUADTREE] = draw_quadtree;
     node[group_name][DISPLAY_NAVMESH] = draw_navmesh;
+    node[group_name][UNDO_REDO_ACTIVE] = undo_redo_active;
 }

--- a/Source/src/core/preferences/src/EditorPreferences.h
+++ b/Source/src/core/preferences/src/EditorPreferences.h
@@ -131,6 +131,16 @@ namespace Hachiko
             return draw_quadtree;
         }
 
+        void SetUndoRedoActive(bool value)
+        {
+            undo_redo_active = value;
+        }
+
+        [[nodiscard]] bool GetUndoRedoActive()
+        {
+            return undo_redo_active;
+        }
+
     private:
         bool display_debug_draw = false;
 
@@ -147,5 +157,6 @@ namespace Hachiko
         bool draw_quadtree = false;
         float fps_threshold = 1000.0f / max_fps;
         Editor::Theme::Type theme = Editor::Theme::Type::DARK;
+        bool undo_redo_active = true;
     };
 }

--- a/Source/src/core/serialization/Definitions.h
+++ b/Source/src/core/serialization/Definitions.h
@@ -237,8 +237,6 @@
 #define IMAGE_HOVER_IMAGE_ID "hover_image_id"
 #define IMAGE_COLOR "image_color"
 #define IMAGE_HOVER_COLOR "hover_image_color"
-#define USE_IMAGE "use_image"
-#define USE_HOVER_IMAGE "use_hover_image"
 #define IMAGE_TILED "image_is_tiled"
 #define IMAGE_X_TILES "image_x_tiles"
 #define IMAGE_Y_TILES "image_y_tiles"

--- a/Source/src/core/serialization/Definitions.h
+++ b/Source/src/core/serialization/Definitions.h
@@ -121,6 +121,7 @@
 #define DISPLAY_QUADTREE "display_quadtree"
 #define DISPLAY_SKYBOX "display_skybox"
 #define DISPLAY_NAVMESH "display_navmesh"
+#define UNDO_REDO_ACTIVE "undo_redo_active"
 #define FULLSCREEN_NODE "fullscreen"
 #define THEME "theme"
 #define VSYNC "vsync"

--- a/Source/src/core/serialization/Definitions.h
+++ b/Source/src/core/serialization/Definitions.h
@@ -238,6 +238,10 @@
 #define IMAGE_HOVER_COLOR "hover_image_color"
 #define USE_IMAGE "use_image"
 #define USE_HOVER_IMAGE "use_hover_image"
+#define IMAGE_TILED "image_is_tiled"
+#define IMAGE_X_TILES "image_x_tiles"
+#define IMAGE_Y_TILES "image_y_tiles"
+#define IMAGE_TILES_PER_SEC "image_tiles_per_second"
 
 // Component Text
 #define FONT_ID "font_id"
@@ -329,6 +333,7 @@
 // ComponentMeshRenderer
 #define RENDERER_MESH_ID "mesh_id"
 #define RENDERER_MATERIAL_ID "material_id"
+#define RENDERER_TINT_COLOR "tint_color"
 
 // Script
 #define SCRIPT_NAME "class_name"

--- a/Source/src/modules/ModuleEditor.cpp
+++ b/Source/src/modules/ModuleEditor.cpp
@@ -116,19 +116,23 @@ bool Hachiko::ModuleEditor::Init()
 
     editor_prefs = App->preferences->GetEditorPreference();
     theme = editor_prefs->GetTheme();
+    undo_redo_active = editor_prefs->GetUndoRedoActive();
     UpdateTheme();
 
 #ifndef PLAY_BUILD
-    std::function create_history_entry = [&](Event& evt) {
-        CreateSnapshot();
-    };
-    App->event->Subscribe(Event::Type::CREATE_EDITOR_HISTORY_ENTRY, create_history_entry);
+    if (undo_redo_active)
+    {
+        std::function create_history_entry = [&](Event& evt) {
+            CreateSnapshot();
+        };
+        App->event->Subscribe(Event::Type::CREATE_EDITOR_HISTORY_ENTRY, create_history_entry);
 
-    std::function enable_history = [&](Event& evt) {
-        const auto state = evt.GetEventData<GameStateEventPayload>().GetState();
-        history_enabled = state == GameStateEventPayload::State::STOPPED;
-    };
-    App->event->Subscribe(Event::Type::GAME_STATE, enable_history);
+        std::function enable_history = [&](Event& evt) {
+            const auto state = evt.GetEventData<GameStateEventPayload>().GetState();
+            history_enabled = state == GameStateEventPayload::State::STOPPED;
+        };
+        App->event->Subscribe(Event::Type::GAME_STATE, enable_history);
+    }
 #endif
     return true;
 }
@@ -517,6 +521,7 @@ bool Hachiko::ModuleEditor::CleanUp()
     ImGui::DestroyContext();
 
     editor_prefs->SetTheme(theme);
+    editor_prefs->SetUndoRedoActive(undo_redo_active);
     return true;
 }
 

--- a/Source/src/modules/ModuleEditor.h
+++ b/Source/src/modules/ModuleEditor.h
@@ -93,6 +93,8 @@ namespace Hachiko
         mutable float4 scene_background{0.1f, 0.1f, 0.1f, 0.1f};
         Component* to_remove = nullptr;
 
+        bool undo_redo_active = true;
+
     private:
         void GenerateDockingSpace();
 

--- a/Source/src/ui/WindowConfiguration.cpp
+++ b/Source/src/ui/WindowConfiguration.cpp
@@ -45,9 +45,9 @@ void Hachiko::WindowConfiguration::Update()
 
     if (ImGui::CollapsingHeader("Engine"))
     {
+        ImGui::Checkbox("Undo/Redo", &App->editor->undo_redo_active);
         App->window->OptionsMenu();
         App->renderer->PerformanceMenu();
-
     }
 
     if (ImGui::CollapsingHeader("Batching"))


### PR DESCRIPTION
This PR adds:
- ComponentImage tint color for the image and hover image
- Serialization of tint colors and tiled data of the ComponentImage (i forgot to add it on my last pr)
- Undo/Redo in settings with saving in preferences
- Fix in ComponentImage logic, some variables were not used and that made an unwanted behaviour