### PR TITLE
Feature: Dash terrain collision

### DIFF
--- a/Gameplay/entities/player/PlayerController.cpp
+++ b/Gameplay/entities/player/PlayerController.cpp
@@ -34,9 +34,6 @@ Hachiko::Scripting::PlayerController::PlayerController(GameObject* game_object)
 	common_bullet.size = 0.f;
 	common_bullet.speed = 50.f;
 	common_bullet.damage = 1.f;
-
-	
-	
 	
 	Weapon red;
 	red.name = "Red";
@@ -71,6 +68,9 @@ Hachiko::Scripting::PlayerController::PlayerController(GameObject* game_object)
 
 void Hachiko::Scripting::PlayerController::OnAwake()
 {
+	_terrain = game_object->scene_owner->GetRoot()->GetFirstChildWithName("Level");
+	_enemies = game_object->scene_owner->GetRoot()->GetFirstChildWithName("Enemies");
+	
 	_dash_charges = _max_dash_charges;
 
 	if (_attack_indicator)
@@ -86,9 +86,6 @@ void Hachiko::Scripting::PlayerController::OnAwake()
 	{
 		_dash_trail->SetActive(false);
 	}
-
-	enemies = game_object->scene_owner->GetRoot()->GetFirstChildWithName("Enemies");
-	dynamic_envi = game_object->scene_owner->GetRoot()->GetFirstChildWithName("Crystals");
 
 	_combat_stats = game_object->GetComponent<Stats>();
 	_combat_stats->_attack_power = 2;
@@ -354,7 +351,19 @@ void Hachiko::Scripting::PlayerController::Dash()
 
 	float3 corrected_dash_final_position;
 	float3 dash_final_position = _dash_start + _dash_direction * _dash_distance;
-	corrected_dash_final_position = GetCorrectedPosition(dash_final_position);
+	// Correct by wall hit
+	bool hit_terrain = GetTerrainCollision(_dash_start, dash_final_position, corrected_dash_final_position);
+	if (hit_terrain)
+	{
+		dash_final_position = corrected_dash_final_position;
+		// Get corrected position with a lot of width radius (navmesh seems to not always match the wall properly)
+		corrected_dash_final_position = Navigation::GetCorrectedPosition(dash_final_position, float3(5.f, 0.5f, 5.f));
+	}
+	else
+	{
+		// Correct normally by navmesh
+		corrected_dash_final_position = GetCorrectedPosition(dash_final_position);
+	}
 	if (corrected_dash_final_position.x < FLT_MAX)
 	{
 		_dash_end = corrected_dash_final_position;
@@ -363,6 +372,7 @@ void Hachiko::Scripting::PlayerController::Dash()
 	{
 		_dash_end = dash_final_position;
 	}
+	
 }
 
 
@@ -514,6 +524,12 @@ float4x4 Hachiko::Scripting::PlayerController::GetMeleeAttackOrigin(float attack
 	return emitter;
 }
 
+bool Hachiko::Scripting::PlayerController::GetTerrainCollision(const float3& start, const float3& end, float3& collision_point) const
+{
+	GameObject* terrain_hit = SceneManagement::Raycast(start, end, &collision_point, _terrain);
+	return terrain_hit != nullptr;
+}
+
 void Hachiko::Scripting::PlayerController::MovementController()
 {
 	DashController();
@@ -531,7 +547,8 @@ void Hachiko::Scripting::PlayerController::MovementController()
 
 	if (IsFalling())
 	{
-		_player_position.y -= 0.25f;
+		constexpr float fall_speed = 25.f;
+		_player_position.y -= fall_speed * Time::DeltaTime();
 
 		if (_dash_start.y - _player_position.y > _falling_distance)
 		{
@@ -772,11 +789,11 @@ void Hachiko::Scripting::PlayerController::AttackController()
 
 void Hachiko::Scripting::PlayerController::PickupParasite(const float3& current_position)
 {
-	if (enemies == nullptr) {
+	if (_enemies == nullptr) {
 		return;
 	}
 
-	std::vector<GameObject*> enemy_children = enemies ? enemies->children : std::vector<GameObject*>();
+	std::vector<GameObject*> enemy_children = _enemies ? _enemies->children : std::vector<GameObject*>();
 
 	for (int i = 0; i < enemy_children.size(); ++i)
 	{

--- a/Gameplay/entities/player/PlayerController.h
+++ b/Gameplay/entities/player/PlayerController.h
@@ -114,6 +114,8 @@ private:
 	void CancelAttack();
 	float4x4 GetMeleeAttackOrigin(float attack_range) const;
 
+	bool GetTerrainCollision(const float3& start, const float3& end, float3& collision_point) const;
+
 	// Player simulation
 	void MovementController();
 	void DashController();
@@ -215,10 +217,9 @@ private:
 	float3 _knock_end = float3::zero;
 	Quat _rotation_start = Quat::identity;
 	Quat _rotation_target = Quat::identity;
-
 	
-	GameObject* enemies;
-	GameObject* dynamic_envi;
+	GameObject* _enemies;
+	GameObject* _terrain;
 
 };
 } // namespace Scripting

--- a/Source/src/Gameplay.cpp
+++ b/Source/src/Gameplay.cpp
@@ -103,15 +103,14 @@ void Hachiko::SceneManagement::SetSkyboxActive(bool v)
     App->renderer->SetDrawSkybox(v);
 }
 
-Hachiko::GameObject* Hachiko::SceneManagement::Raycast(const float3& origin, 
-    const float3& destination)
+Hachiko::GameObject* Hachiko::SceneManagement::Raycast(const float3& origin, const float3& destination, float3* closest_hit, GameObject* parent_filter)
 {
-    return App->scene_manager->Raycast(origin, destination);
+    return App->scene_manager->Raycast(origin, destination, closest_hit, parent_filter);
 }
 
-Hachiko::GameObject* Hachiko::SceneManagement::BoundingRaycast(const float3& origin, const float3& destination)
+Hachiko::GameObject* Hachiko::SceneManagement::BoundingRaycast(const float3& origin, const float3& destination, GameObject* parent_filter)
 {
-    return App->scene_manager->Raycast(origin, destination);
+    return App->scene_manager->Raycast(origin, destination, nullptr, parent_filter);
 }
 
 Hachiko::GameObject* Hachiko::SceneManagement::FindInCurrentScene(

--- a/Source/src/Gameplay.h
+++ b/Source/src/Gameplay.h
@@ -409,8 +409,8 @@ namespace Hachiko::SceneManagement
 {
 HACHIKO_API void SwitchScene(unsigned long long scene_uid);
 HACHIKO_API void SetSkyboxActive(bool v);
-HACHIKO_API GameObject* Raycast(const float3& origin, const float3& destination);
-HACHIKO_API GameObject* BoundingRaycast(const float3& origin, const float3& destination);
+HACHIKO_API GameObject* Raycast(const float3& origin, const float3& destination, float3* closest_hit = nullptr, GameObject* parent_filter = nullptr);
+HACHIKO_API GameObject* BoundingRaycast(const float3& origin, const float3& destination, GameObject* parent_filter = nullptr);
 HACHIKO_API GameObject* FindInCurrentScene(unsigned long long id);
 HACHIKO_API std::vector<GameObject*> Instantiate(unsigned long long prefab_uid, GameObject* parent, unsigned n_instances);
 HACHIKO_API void Destroy(GameObject* game_object);

--- a/Source/src/core/Scene.h
+++ b/Source/src/core/Scene.h
@@ -44,9 +44,9 @@ namespace Hachiko
 
         void RebuildBatching();
 
-        [[nodiscard]] GameObject* Raycast(const float3& origin, const float3& destination) const;
-        [[nodiscard]] GameObject* BoundingRaycast(const float3& origin, const float3& destination) const;
-        [[nodiscard]] GameObject* Raycast(const LineSegment& segment, bool triangle_level = true) const;
+        [[nodiscard]] GameObject* Raycast(const float3& origin, const float3& destination, float3* closest_hit = nullptr, GameObject* parent_filter = nullptr) const;
+        [[nodiscard]] GameObject* BoundingRaycast(const float3& origin, const float3& destination, GameObject* parent_filter = nullptr) const;
+        [[nodiscard]] GameObject* Raycast(const LineSegment& segment, bool triangle_level = true, float3* closest_hit = nullptr, GameObject* parent_filter = nullptr) const;
 
         [[nodiscard]] GameObject* GetRoot() const
         {
@@ -151,6 +151,8 @@ namespace Hachiko
         bool rebuild_batch = true;
         BatchManager* batch_manager = nullptr;
         std::vector<Component*> particles{};
+
+        
 
     public:
         class Memento

--- a/Source/src/modules/ModuleSceneManager.cpp
+++ b/Source/src/modules/ModuleSceneManager.cpp
@@ -266,14 +266,14 @@ void Hachiko::ModuleSceneManager::SaveScene(const char* save_name)
     UID saved_scene_uid = scene_importer.CreateSceneAsset(main_scene);
 }
 
-Hachiko::GameObject* Hachiko::ModuleSceneManager::Raycast(const float3& origin, const float3& destination)
+Hachiko::GameObject* Hachiko::ModuleSceneManager::Raycast(const float3& origin, const float3& destination, float3* closest_hit, GameObject* parent_filter)
 {
-    return main_scene->Raycast(origin, destination);
+    return main_scene->Raycast(origin, destination, closest_hit, parent_filter);
 }
 
-Hachiko::GameObject* Hachiko::ModuleSceneManager::BoundingRaycast(const float3& origin, const float3& destination)
+Hachiko::GameObject* Hachiko::ModuleSceneManager::BoundingRaycast(const float3& origin, const float3& destination, GameObject* parent_filter)
 {
-    return main_scene->Raycast(origin, destination);
+    return main_scene->Raycast(origin, destination, nullptr, parent_filter);
 }
 
 void Hachiko::ModuleSceneManager::ChangeSceneById(UID new_scene_id, bool stop_scene)

--- a/Source/src/modules/ModuleSceneManager.h
+++ b/Source/src/modules/ModuleSceneManager.h
@@ -57,8 +57,8 @@ namespace Hachiko
         
         void SaveScene(const char* file_path = nullptr);
 
-        GameObject* Raycast(const float3& origin, const float3& destination);
-        GameObject* BoundingRaycast(const float3& origin, const float3& destination);
+        GameObject* Raycast(const float3& origin, const float3& destination, float3* closest_hit = nullptr, GameObject* parent_filter = nullptr);
+        GameObject* BoundingRaycast(const float3& origin, const float3& destination, GameObject* parent_filter = nullptr);
 
         void OptionsMenu();
 


### PR DESCRIPTION
Changes
- You can pass a parent go to be filtered in raycast (optional param)
- You can pass a float3 pointer to get the raycast hit point (only for triangle level raycast now), it is transformed to global coords before being returned
- Player uses the previous two features in combination with navmesh position correction with extra x, z tolerance to not dash over walls (navmesh was away from the hit point on multiple places).
- Set fall speed to depend on deltatime
