### PR TITLE
Improvement: Fall behavior

### DIFF
--- a/Gameplay/entities/player/PlayerController.cpp
+++ b/Gameplay/entities/player/PlayerController.cpp
@@ -730,11 +730,24 @@ void Hachiko::Scripting::PlayerController::MovementController()
 
 		if (_start_fall_pos.y - _player_position.y > _falling_distance)
 		{
+			// If the player is going to die falling respawn him
+			if (GetCurrentHp() == 1)
+			{
+				_level_manager->Respawn(this);
+				_state = PlayerState::IDLE;
+				return;
+			}
+
+			// Fall dmg
+			RegisterHit(1);
+
+			// If its still alive place it in the first valid position, if none exists respawn it
 			_player_position = GetLastValidDashOrigin();
 			if (_player_position.x >= FLT_MAX)
 			{
 				_level_manager->Respawn(this);
 			}
+			_state = PlayerState::IDLE;
 		}
 	}
 	else if (IsStunned())
@@ -1045,7 +1058,7 @@ void Hachiko::Scripting::PlayerController::PickupParasite(const float3& current_
 	}
 }
 
-void Hachiko::Scripting::PlayerController::RegisterHit(float damage_received, float knockback, float3 direction)
+void Hachiko::Scripting::PlayerController::RegisterHit(int damage_received, float knockback, float3 direction)
 {
 	if (_god_mode)
 	{

--- a/Gameplay/entities/player/PlayerController.h
+++ b/Gameplay/entities/player/PlayerController.h
@@ -90,13 +90,14 @@ namespace Hachiko
 			PlayerState GetState() const;
 
 			void CheckGoal(const float3& current_position);
-			void RegisterHit(float damage_received, float knockback = 0, math::float3 direction = float3::zero);
+			void RegisterHit(int damage, float knockback = 0, math::float3 direction = float3::zero);
 			void UpdateHealthBar();
 			void UpdateAmmoUI();
 			void UpdateWeaponChargeUI();
 			void ToggleGodMode();
 
-			bool IsAlive() { return _combat_stats->_current_hp > 0; }
+			bool IsAlive() const { return _combat_stats->_current_hp > 0; }
+			int GetCurrentHp() const { return _combat_stats->_current_hp; }
 			bool _isInDebug = false;
 
 			int GetAttackIndex() const

--- a/Gameplay/entities/player/PlayerController.h
+++ b/Gameplay/entities/player/PlayerController.h
@@ -144,6 +144,8 @@ namespace Hachiko
 			// Actions called by handle input
 			void Dash();
 			void CorrectDashDestination(const float3& dash_source, float3& dash_destination);
+			void StoreDashOrigin(const float3& dash_origin);
+			float3 GetLastValidDashOrigin();
 			void MeleeAttack();
 			void ChangeWeapon(unsigned weapon_idx);
 			void RangedAttack();
@@ -228,7 +230,6 @@ namespace Hachiko
 			ComponentParticleSystem* _walking_dust_particles = nullptr;
 			ComponentParticleSystem* _heal_effect_particles_1 = nullptr;
 			ComponentParticleSystem* _heal_effect_particles_2 = nullptr;
-
 			
 			std::vector<Weapon> weapons{};
 
@@ -246,6 +247,8 @@ namespace Hachiko
 			float3 _dash_start = float3::zero;
 			float3 _dash_end = float3::zero;
 			float3 _dash_direction = float3::zero;
+			const unsigned max_dashed_from_positions = 5;
+			std::deque<float3> dashed_from_positions;
 
 			float3 _trail_start_pos = float3::zero;
 			float3 _trail_start_scale = float3::zero;

--- a/Source/src/core/Scene.cpp
+++ b/Source/src/core/Scene.cpp
@@ -136,7 +136,22 @@ Hachiko::GameObject* Hachiko::Scene::Raycast(const LineSegment& segment, bool tr
 
     for (GameObject* game_object : game_objects)
     {
-        if (parent_filter && parent_filter != game_object->parent) continue;
+        constexpr unsigned max_levels_search = 5;
+        if (parent_filter)
+        {
+            unsigned level = 0;
+            
+            GameObject* find_parent = game_object->parent;
+
+            while (find_parent && find_parent != parent_filter && level < max_levels_search)
+            {
+                find_parent = find_parent->parent;
+                ++level;
+            }
+
+            if (find_parent != parent_filter) continue;
+        }
+
         if (active_only && !game_object->IsActive()) continue;
         
         auto* mesh_renderer = game_object->GetComponent<ComponentMeshRenderer>();


### PR DESCRIPTION
- If u fall there is a queue of all dashed from positions and u get placed in the first valid one. This prevents bugs when trying to respawn on disappeared platforms, will be a somewhat edge case but better make it robust.
- Added fall damage, if u are going to die on fall  u get respawned.
- Added a "dirty" fix for terrain collisions, since latest level had multiple levels for meshes increased the serch depth of the parent to match.

To test play level 