### PR TITLE
Add navmesh raycast

### DIFF
--- a/Source/src/Gameplay.cpp
+++ b/Source/src/Gameplay.cpp
@@ -348,6 +348,11 @@ void Hachiko::Navigation::CorrectPosition(math::float3& position, const math::fl
     return App->navigation->CorrectPosition(position, extents);
 }
 
+bool Hachiko::Navigation::Raycast(const float3& start_pos, const float3& end_pos, float3& hit_position)
+{
+    return App->navigation->Raycast(start_pos, end_pos, hit_position);
+}
+
 /*---------------------------------------------------------------------------*/
 
 /*PROPERTIES-----------------------------------------------------------------*/

--- a/Source/src/Gameplay.h
+++ b/Source/src/Gameplay.h
@@ -482,6 +482,7 @@ namespace Hachiko::Navigation
     HACHIKO_API float GetHeightFromPosition(const math::float3& position);
     HACHIKO_API math::float3 GetCorrectedPosition(const math::float3& position, const math::float3& extents);
     HACHIKO_API void CorrectPosition(math::float3& position, const math::float3& extents);
+    HACHIKO_API bool Raycast(const float3& start_pos, const float3& end_pos, float3& hit_position);
 } // namespace Hachiko::Navigation
 
 namespace Hachiko::FileUtility

--- a/Source/src/modules/ModuleNavigation.cpp
+++ b/Source/src/modules/ModuleNavigation.cpp
@@ -274,6 +274,34 @@ dtCrowdAgent* Hachiko::ModuleNavigation::GetEditableAgent(int agent_id) const
     return crowd->getEditableAgent(agent_id);
 }
 
+bool Hachiko::ModuleNavigation::Raycast(const float3& start_pos, const float3& end_pos, float3& hit_position)
+{
+    if (!scene_navmesh) return false;
+
+    bool hit = false;
+    dtPolyRef poly_ref;
+    float3 extension(2, 4, 2);
+    dtQueryFilter filter;
+    scene_navmesh->navigation_query->findNearestPoly(start_pos.ptr(), extension.ptr(), &filter, &poly_ref, 0);
+    if (poly_ref)
+    {
+        float3 hit_normal;
+        float t = 0.f;
+        int npolys = 0;
+        static const int MAX_POLYS = 5;
+        dtPolyRef polys[MAX_POLYS];
+        scene_navmesh->navigation_query->raycast(poly_ref, start_pos.ptr(), end_pos.ptr(), &filter, &t, hit_normal.ptr(), polys, &npolys, MAX_POLYS);
+
+        if (t < FLT_MAX)
+        {
+            hit = true;
+            dtVlerp(hit_position.ptr(), start_pos.ptr(), end_pos.ptr(), t);
+        }
+    }
+    
+    return hit;
+}
+
 void Hachiko::ModuleNavigation::UpdateObstacleStats(dtTileCache* tile_cache)
 {
     total_obstacle_slots = tile_cache->getObstacleCount();

--- a/Source/src/modules/ModuleNavigation.cpp
+++ b/Source/src/modules/ModuleNavigation.cpp
@@ -276,7 +276,10 @@ dtCrowdAgent* Hachiko::ModuleNavigation::GetEditableAgent(int agent_id) const
 
 bool Hachiko::ModuleNavigation::Raycast(const float3& start_pos, const float3& end_pos, float3& hit_position)
 {
-    if (!scene_navmesh) return false;
+    if (!scene_navmesh) 
+    {
+        return false;
+    }
 
     bool hit = false;
     dtPolyRef poly_ref;

--- a/Source/src/modules/ModuleNavigation.h
+++ b/Source/src/modules/ModuleNavigation.h
@@ -45,6 +45,8 @@ namespace Hachiko
         const dtCrowdAgent* GetAgent(int agent_id) const;
         dtCrowdAgent* GetEditableAgent(int agent_id) const;
 
+        bool Raycast(const float3& start_pos, const float3& end_pos, float3& hit_position);
+
     private:
         void SetDebugData();
         void RenderAgents(duDebugDraw& dd);


### PR DESCRIPTION
It returns the edge of the navmesh as hit point and its updated by obstacles, the only issue is that it would prevent us from dashing in the air if we only use this. 
Just adding it to the engine for now.