### PR TITLE
Fix worm invisible && attacking right at spawn

### DIFF
--- a/Game/assets/state_machine/wormDistanceSM.stm
+++ b/Game/assets/state_machine/wormDistanceSM.stm
@@ -12,7 +12,7 @@ clips:
     clips_loop: true
   - clip_name: RangeAttack
     clips_id: 7582254748141028466
-    clips_loop: true
+    clips_loop: false
   - clip_name: Hit
     clips_id: 9554448594809014923
     clips_loop: false

--- a/Game/assets/state_machine/wormDistanceSM.stm
+++ b/Game/assets/state_machine/wormDistanceSM.stm
@@ -35,60 +35,30 @@ nodes:
     node_clip_name: Hide
   - node_name: Dead
     node_clip_name: Dead
+  - node_name: ANY
+    node_clip_name: none
 transitions:
-  - transition_source: Iddle
-    transition_target: Appear
-    transition_trigger: isAppear
-    transition_blend: 0
-  - transition_source: Iddle
+  - transition_source: ANY
     transition_target: RangeAttack
     transition_trigger: isAttacking
     transition_blend: 300
-  - transition_source: Iddle
+  - transition_source: ANY
     transition_target: Dead
     transition_trigger: isDead
     transition_blend: 300
-  - transition_source: Iddle
+  - transition_source: ANY
     transition_target: Hide
     transition_trigger: isHide
     transition_blend: 300
-  - transition_source: Iddle
+  - transition_source: ANY
     transition_target: Hit
     transition_trigger: isHit
     transition_blend: 300
-  - transition_source: Appear
+  - transition_source: ANY
     transition_target: Iddle
     transition_trigger: idle
     transition_blend: 300
-  - transition_source: RangeAttack
-    transition_target: Hide
-    transition_trigger: isHide
-    transition_blend: 300
-  - transition_source: Hide
+  - transition_source: ANY
     transition_target: Appear
     transition_trigger: isAppear
-    transition_blend: 1
-  - transition_source: Hit
-    transition_target: Dead
-    transition_trigger: isDead
-    transition_blend: 300
-  - transition_source: Hit
-    transition_target: Hide
-    transition_trigger: isHide
-    transition_blend: 300
-  - transition_source: RangeAttack
-    transition_target: Iddle
-    transition_trigger: idle
-    transition_blend: 300
-  - transition_source: Hit
-    transition_target: Iddle
-    transition_trigger: idle
-    transition_blend: 300
-  - transition_source: RangeAttack
-    transition_target: Hit
-    transition_trigger: isHit
-    transition_blend: 300
-  - transition_source: Hide
-    transition_target: Appear
-    transition_trigger: ""
     transition_blend: 300

--- a/Game/assets/state_machine/wormDistanceSM.stm.meta
+++ b/Game/assets/state_machine/wormDistanceSM.stm.meta
@@ -1,5 +1,5 @@
-asset_hash: 7877353704041793978
+asset_hash: 17032272539262977726
 resources:
   - resource_id: 17649947854538430141
     resource_type: 14
-    resource_hash: 7877353704041793978
+    resource_hash: 17032272539262977726

--- a/Game/assets/state_machine/wormDistanceSM.stm.meta
+++ b/Game/assets/state_machine/wormDistanceSM.stm.meta
@@ -1,5 +1,5 @@
-asset_hash: 17032272539262977726
+asset_hash: 11606731621245437054
 resources:
   - resource_id: 17649947854538430141
     resource_type: 14
-    resource_hash: 17032272539262977726
+    resource_hash: 11606731621245437054

--- a/Gameplay/entities/enemies/EnemyController.cpp
+++ b/Gameplay/entities/enemies/EnemyController.cpp
@@ -262,6 +262,7 @@ void Hachiko::Scripting::EnemyController::SpawnController()
 			_big_dust_particles->Restart();
 			//Push the player back
 			_combat_manager->EnemyMeleeAttack(transform->GetGlobalMatrix(), push_attack);
+			_attack_cooldown = _combat_stats->_attack_cd;
 			return;
 		}
 
@@ -421,14 +422,16 @@ void Hachiko::Scripting::EnemyController::AttackController()
 		}
 		break;
 	case EnemyType::WORM:
+
 		if (_attack_cooldown > 0.0f)
 		{
 			return;
 		}
 
-		if (_state != BugState::ATTACKING && !_attack_landing)
+		if (_previous_state == BugState::IDLE && _state != BugState::ATTACKING && !_attack_landing)
 		{
 			_state = BugState::ATTACKING;
+			return;
 		}
 
 		WormSpit();
@@ -855,7 +858,7 @@ void Hachiko::Scripting::EnemyController::PatrolMovement()
 
 void Hachiko::Scripting::EnemyController::WormSpit()
 {
-	if (animation->IsAnimationStopped())
+	if (_state == BugState::ATTACKING && animation->IsAnimationStopped())
 	{
 		// We create the attack zone once the firing animation is done
 		_state = BugState::IDLE;

--- a/Gameplay/entities/enemies/EnemyController.cpp
+++ b/Gameplay/entities/enemies/EnemyController.cpp
@@ -184,6 +184,12 @@ void Hachiko::Scripting::EnemyController::OnUpdate()
 {
 	CheckState();
 
+	if (_state == BugState::INVALID && !_has_spawned)
+	{
+		Spawn();
+		return;
+	}
+
 	if (_current_spawning_time > 0.0f || _state == BugState::SPAWNING)
 	{
 		SpawnController();
@@ -628,7 +634,7 @@ void Hachiko::Scripting::EnemyController::Spawn()
 		_state = BugState::INVALID;
 		_small_dust_particles->Restart();
 		_current_spawning_time = _spawning_time;
-		_player_camera->Shake(_spawning_time, 0.2f);
+		_player_camera->Shake(_spawning_time, 0.8f);
 		break;
 	}
 }
@@ -710,7 +716,7 @@ void Hachiko::Scripting::EnemyController::ResetEnemy()
 	_is_stunned = false;
 	_has_spawned = false;
 	_attack_delay = 0.3f;
-	_state = BugState::IDLE;
+	_state = BugState::INVALID;
 	_previous_state = BugState::INVALID;
 	_parasite_dissolving_time_progress = 0.f;
 	_enemy_dissolving_time_progress = 0.f;
@@ -730,6 +736,26 @@ void Hachiko::Scripting::EnemyController::ResetEnemy()
 	if (_blood_trail_particles != nullptr)
 	{
 		_blood_trail_particles->Disable();
+	}
+
+	if (_inner_indicator_billboard != nullptr)
+	{
+		_inner_indicator_billboard->Stop();
+	}
+
+	if (_outer_indicator_billboard != nullptr)
+	{
+		_outer_indicator_billboard->Stop();
+	}
+
+	if (_big_dust_particles != nullptr)
+	{
+		_big_dust_particles->Stop();
+	}
+
+	if (_small_dust_particles != nullptr)
+	{
+		_small_dust_particles->Stop();
 	}
 }
 

--- a/Gameplay/entities/enemies/EnemyController.cpp
+++ b/Gameplay/entities/enemies/EnemyController.cpp
@@ -426,44 +426,28 @@ void Hachiko::Scripting::EnemyController::AttackController()
 			return;
 		}
 
-		if (!_attack_landing)
+		if (_state != BugState::ATTACKING && !_attack_landing)
 		{
-			_attack_zone->GetTransform()->SetGlobalPosition(_player_pos);
-			WormSpit();
-			_attack_animation_timer = 0.0f;
+			_state = BugState::ATTACKING;
 		}
-		else
-		{
-			_attack_animation_timer += Time::DeltaTime();
-			if (_attack_animation_timer >= 1.0f)
-			{
-				CombatManager::AttackStats attack_stats;
-				attack_stats.damage = _combat_stats->_attack_power;
-				attack_stats.knockback_distance = 0.0f;
-				attack_stats.width = 0.f;
-				attack_stats.range = 2.5; // a bit bigger than its attack activation range
-				attack_stats.type = CombatManager::AttackType::CIRCLE;
-				_combat_manager->EnemyMeleeAttack(_attack_zone->GetTransform()->GetGlobalMatrix(), attack_stats);
-				_attack_landing = false;
-				_attack_cooldown = _combat_stats->_attack_cd;
-				_state = BugState::IDLE;
-			}
-		}
+
+		WormSpit();
+
 		return;
 	}
 }
 
 void Hachiko::Scripting::EnemyController::IdleController()
 {
-	if (_state == BugState::ATTACKING && animation->IsAnimationStopped())
-	{
-		_state = BugState::IDLE;
-	}
-
 	if (_enemy_type == EnemyType::WORM)
 	{
 		_enemy_body->GetTransform()->LookAtTarget(_player_pos);
 		return;
+	}
+
+	if (_state == BugState::ATTACKING && animation->IsAnimationStopped())
+	{
+		_state = BugState::IDLE;
 	}
 
 	if (_state == BugState::IDLE)
@@ -871,9 +855,34 @@ void Hachiko::Scripting::EnemyController::PatrolMovement()
 
 void Hachiko::Scripting::EnemyController::WormSpit()
 {
-	_state = BugState::ATTACKING;
-	_attack_landing = true;
-	_attack_current_delay = 1.0f;
-	_inner_indicator_billboard->Play();
-	_outer_indicator_billboard->Play();
+	if (animation->IsAnimationStopped())
+	{
+		// We create the attack zone once the firing animation is done
+		_state = BugState::IDLE;
+		_attack_zone->GetTransform()->SetGlobalPosition(_player_pos);
+		_attack_landing = true;
+		_attack_current_delay = 1.0f;
+		_inner_indicator_billboard->Play();
+		_outer_indicator_billboard->Play();
+		_attack_animation_timer = 0.0f;
+
+		return;
+	}
+
+	if (_attack_landing)
+	{
+		_attack_animation_timer += Time::DeltaTime();
+		if (_attack_animation_timer >= 1.0f)
+		{
+			CombatManager::AttackStats attack_stats;
+			attack_stats.damage = _combat_stats->_attack_power;
+			attack_stats.knockback_distance = 0.0f;
+			attack_stats.width = 0.f;
+			attack_stats.range = 2.5; // a bit bigger than its attack activation range
+			attack_stats.type = CombatManager::AttackType::CIRCLE;
+			_combat_manager->EnemyMeleeAttack(_attack_zone->GetTransform()->GetGlobalMatrix(), attack_stats);
+			_attack_landing = false;
+			_attack_cooldown = _combat_stats->_attack_cd;
+		}
+	}
 }

--- a/Gameplay/entities/enemies/EnemyController.cpp
+++ b/Gameplay/entities/enemies/EnemyController.cpp
@@ -463,6 +463,7 @@ void Hachiko::Scripting::EnemyController::IdleController()
 	if (_enemy_type == EnemyType::WORM)
 	{
 		_enemy_body->GetTransform()->LookAtTarget(_player_pos);
+		return;
 	}
 
 	if (_state == BugState::IDLE)


### PR DESCRIPTION
The bug was happening on second and third gauntlet if you died. You can try there.
Also, now the worm's attack indicator appears after it attacks, because in theory it was ment to shoot upwards during animation and then it would fall, if you want this reverted just tell me.