### PR TITLE
Fix: obstacle bugs

### DIFF
--- a/Gameplay/entities/crystals/CrystalExplosion.cpp
+++ b/Gameplay/entities/crystals/CrystalExplosion.cpp
@@ -35,10 +35,6 @@ void Hachiko::Scripting::CrystalExplosion::OnAwake()
 	_stats = game_object->GetComponent<Stats>();
 	_audio_source = game_object->GetComponent<ComponentAudioSource>();
 	transform = game_object->GetTransform();
-}
-
-void Hachiko::Scripting::CrystalExplosion::OnStart()
-{
 	ResetCrystal();
 }
 
@@ -218,7 +214,6 @@ void Hachiko::Scripting::CrystalExplosion::ResetCrystal()
 	ComponentObstacle* obstacle = game_object->GetComponent<ComponentObstacle>();
 	if (obstacle)
 	{
-		obstacle->Enable();
 		obstacle->AddObstacle();
 	}
 
@@ -239,7 +234,6 @@ void Hachiko::Scripting::CrystalExplosion::DestroyCrystal()
 	if (obstacle)
 	{
 		obstacle->RemoveObstacle();
-		obstacle->Disable();
 	}
 	ComponentAnimation* exploding_animation = _explosion_crystal->GetComponent<ComponentAnimation>();
 	if (exploding_animation)

--- a/Gameplay/entities/crystals/CrystalExplosion.h
+++ b/Gameplay/entities/crystals/CrystalExplosion.h
@@ -21,7 +21,6 @@ namespace Hachiko
 
 
 			void OnAwake() override;
-			void OnStart() override;
 			void OnUpdate() override;
 
 			void StartExplosion();

--- a/Gameplay/entities/player/CombatVisualEffectsPool.cpp
+++ b/Gameplay/entities/player/CombatVisualEffectsPool.cpp
@@ -17,7 +17,6 @@ void Hachiko::Scripting::CombatVisualEffectsPool::OnAwake()
 	for (ComponentBillboard* billboard : game_object->GetComponentsInDescendants<ComponentBillboard>())
 	{
 		_billboards.push_back(billboard);
-		HE_LOG("%s", billboard->GetGameObject()->GetName().c_str());
 	}
 }
 

--- a/Gameplay/misc/DoorController.cpp
+++ b/Gameplay/misc/DoorController.cpp
@@ -17,27 +17,27 @@ void Hachiko::Scripting::DoorController::OnAwake()
 
 void Hachiko::Scripting::DoorController::OnUpdate()
 {
-	if (Input::IsKeyDown(Input::KeyCode::KEY_1))
-	{
-		_state = _state == State::CLOSED ? State::OPEN : State::CLOSED;
-		UpdateDoorState();
-	}
+	UpdateDoorState();
 }
 
 void Hachiko::Scripting::DoorController::Open()
 {
 	_state = State::OPEN;
-	UpdateDoorState();
 }
 
 void Hachiko::Scripting::DoorController::Close()
 {
 	_state = State::CLOSED;
-	UpdateDoorState();
 }
 
 void Hachiko::Scripting::DoorController::UpdateDoorState()
 {
+	if (_prev_state == _state)
+	{
+		return;
+	}
+	_prev_state = _state;
+
 	switch (_state)
 	{
 	case State::CLOSED:

--- a/Gameplay/misc/DoorController.h
+++ b/Gameplay/misc/DoorController.h
@@ -40,7 +40,8 @@ namespace Hachiko
 			ComponentObstacle* door_obstacle = nullptr;
 
 		private:
-			State _state = State::CLOSED;
+			State _prev_state = State::OPEN;
+			State _state = State::OPEN;
 		};
 	}
 	

--- a/Source/src/components/ComponentObstacle.cpp
+++ b/Source/src/components/ComponentObstacle.cpp
@@ -15,11 +15,6 @@ Hachiko::ComponentObstacle::~ComponentObstacle()
     RemoveObstacle();
 }
 
-void Hachiko::ComponentObstacle::Start()
-{
-    AddObstacle();
-}
-
 void Hachiko::ComponentObstacle::Stop()
 {
     RemoveObstacle();
@@ -141,7 +136,7 @@ void Hachiko::ComponentObstacle::AddObstacle()
         tile_cache->addBoxObstacle(transform->GetGlobalPosition().ptr(), (size / 2.f).ptr(), transform->GetGlobalRotation().ToEulerXYZ().z, obstacle);
         break;
     }
-
+    
     if (!obstacle)
     {
         HE_LOG("Failed to add obstacle with existing navmesh and tile cache");
@@ -162,7 +157,7 @@ void Hachiko::ComponentObstacle::RemoveObstacle()
         HE_LOG("Failed to remove obstacle from unexisting tile cache");
         return;
     }
-
+    
     tile_cache->removeObstacle(*obstacle);
     RELEASE(obstacle);
 }

--- a/Source/src/components/ComponentObstacle.h
+++ b/Source/src/components/ComponentObstacle.h
@@ -3,7 +3,6 @@
 #include "components/Component.h"
 #include "Globals.h"
 
-//enum ObstacleType;
 typedef unsigned int dtObstacleRef;
 
 namespace Hachiko
@@ -27,7 +26,6 @@ namespace Hachiko
         ComponentObstacle(GameObject* container);
         ~ComponentObstacle() override;
         
-        void Start() override; // Call AddObstacle
         void Stop() override; // Call RemoveObstacle
         virtual void Update() override; // Updates the obstacle (if dirty) every x ticks to prevent tile cache collapse
         virtual void OnTransformUpdated() override; // Sets the obstacle as dirty        

--- a/Source/src/core/GameObject.cpp
+++ b/Source/src/core/GameObject.cpp
@@ -291,6 +291,10 @@ void Hachiko::GameObject::Start()
 
         for (Component* component : components)
         {
+            if (component->GetType() == Component::Type::SCRIPT)
+            {
+                continue;
+            }
             component->Start();
         }
         started = true;


### PR DESCRIPTION
Obstacles are no longer added on scene start automatically (This could be changed but it made sense since all scripts had stuff to add them)
Crystals and doors are now added a single time consistently when the level starts (this was the main cause of the bug)

To test play level, character freezes on worm spawn but its unrelated will look at it