### PR TITLE
Fixed crash when loading Level 2 from Level 1

### DIFF
--- a/Source/src/components/ComponentParticleSystem.cpp
+++ b/Source/src/components/ComponentParticleSystem.cpp
@@ -63,7 +63,7 @@ void Hachiko::ComponentParticleSystem::Start()
 
     std::function selection_changed = [&](Event& evt) {
         const auto data = evt.GetEventData<SelectionChangedEventPayload>();
-        if (data.GetSelected() != GetGameObject())
+        if (!data.GetSelected() || data.GetSelected() != GetGameObject())
         {
             Pause();
         }


### PR DESCRIPTION
Hello.

This should fix the crash that was preventing Level 2 from being loaded after completing Level 1.
**How to test:** Activate godmode, run towards the door of Level 2 and it should be loaded succesfully.

Dont hesitate to dm on Discord if you see something. Cheers!