### PR TITLE
Finishing level2 sends you to the menu

### DIFF
--- a/Game/assets/scenes/Level2.scene
+++ b/Game/assets/scenes/Level2.scene
@@ -12630,7 +12630,7 @@ child:
         type: 15
         enabled: true
         class_name: LevelManager
-        "'_level@unsigned'": 1
+        "'_level@unsigned'": 2
         "'_respawn_position@float3'": [-85, 1.49, 3.16]
         "'_gauntlet_ui_go@GameObject*'": 5741094800248935353
         "'_gauntlet_counter_go@GameObject*'": 13853085409061284678


### PR DESCRIPTION
It is just that, i made the code before the last follow up but we forgot to set the level manager on the level2 to 2. Now reaching the goal in level2 sends you to menus.

Any change in level2 can override this one, it is a very very small thing, there is no problem, just let me know.