### PR TITLE
Fix/fps problem

### DIFF
--- a/Gameplay/entities/enemies/BossController.cpp
+++ b/Gameplay/entities/enemies/BossController.cpp
@@ -65,6 +65,8 @@ void Hachiko::Scripting::BossController::RegisterHit(int dmg)
 	{
 		combat_stats->_current_hp -= dmg;
 		UpdateHpBar();
+
+		game_object->ChangeEmissiveColor(float4(255, 255, 255, 255), 0.3f, true);
 	}
 }
 

--- a/Gameplay/entities/enemies/EnemyController.cpp
+++ b/Gameplay/entities/enemies/EnemyController.cpp
@@ -476,7 +476,7 @@ void Hachiko::Scripting::EnemyController::BeetleAttackController()
 	float dist_to_player = _current_pos.Distance(_player_pos);
 
 	// If an enemy is from a gautlet, it will always follow the player
-	if (_is_from_gautlet || dist_to_player < _aggro_range || _enraged > 0.0f)
+	if ((_is_from_gautlet || dist_to_player < _aggro_range || _enraged > 0.0f) && _player_controller->IsAlive())
 	{
 		if (dist_to_player <= _attack_range)
 		{

--- a/Gameplay/entities/player/PlayerController.h
+++ b/Gameplay/entities/player/PlayerController.h
@@ -138,7 +138,7 @@ namespace Hachiko
 		private:
 			math::float3 GetRaycastPosition(
 				const math::float3& current_position) const;
-			float3 GetCorrectedPosition(const float3& target_pos) const;
+			float3 GetCorrectedPosition(const float3& target_pos, bool fps_relative = false) const;
 
 			PlayerAttack GetAttackType(AttackType attack_type);
 
@@ -214,6 +214,8 @@ namespace Hachiko
 			bool _god_mode_trigger = false;
 
 		private:
+			const float fall_speed = 25.f;
+
 			SERIALIZE_FIELD(GameObject*, _attack_indicator);
 			SERIALIZE_FIELD(GameObject*, _bullet_emitter);
 			SERIALIZE_FIELD(GameObject*, _goal);

--- a/Source/src/components/ComponentParticleSystem.cpp
+++ b/Source/src/components/ComponentParticleSystem.cpp
@@ -62,7 +62,7 @@ void Hachiko::ComponentParticleSystem::Start()
     };
     App->event->Subscribe(Event::Type::CURVE_EDITOR, edit_curve, GetID());
 
-    std::function selection_changed = [&](Event& evt) {
+    /* std::function selection_changed = [&](Event& evt) {
         const auto data = evt.GetEventData<SelectionChangedEventPayload>();
         if (!data.GetSelected() || data.GetSelected() != GetGameObject())
         {
@@ -73,7 +73,7 @@ void Hachiko::ComponentParticleSystem::Start()
             Play();
         }
     };
-    App->event->Subscribe(Event::Type::SELECTION_CHANGED, selection_changed, GetID());
+    App->event->Subscribe(Event::Type::SELECTION_CHANGED, selection_changed, GetID());*/
     emitter_state = ParticleSystem::Emitter::State::PLAYING;
 }
 

--- a/Source/src/components/ComponentText.cpp
+++ b/Source/src/components/ComponentText.cpp
@@ -199,17 +199,25 @@ void Hachiko::ComponentText::RefreshLabel(ComponentTransform2D* transform)
 {
     if (dirty)
     {
-        unsigned windowWidth, windowHeight;
-        App->camera->GetRenderingCamera()->GetResolution(windowWidth, windowHeight);
-        label->setWindowSize(windowWidth, windowHeight);
-        const float2& size = transform->GetSize();
+        try
+        {
+            unsigned windowWidth, windowHeight;
+            App->camera->GetRenderingCamera()->GetResolution(windowWidth, windowHeight);
+            label->setWindowSize(windowWidth, windowHeight);
+            const float2& size = transform->GetSize();
 
-        const float4x4& trf = transform->GetGlobalTransform();
-        const float3& pos = trf.TranslatePart();
-        label->scale(trf.scaleX, trf.scaleY, trf.scaleZ);
-        label->setSize(size.x, size.y);
-        label->setPosition(pos.x + (windowWidth / 2), pos.y + (windowHeight / 2));
-        dirty = false;
+            const float4x4& trf = transform->GetGlobalTransform();
+            const float3& pos = trf.TranslatePart();
+            label->scale(trf.scaleX, trf.scaleY, trf.scaleZ);
+            label->setSize(size.x, size.y);
+            label->setPosition(pos.x + (windowWidth / 2), pos.y + (windowHeight / 2));
+            dirty = false;
+        }
+        catch (std::exception& e)
+        {
+            // Catch exception and return unloaded font if fails
+            HE_LOG("Failed to RefreshLabel");
+        }
     }
 }
 

--- a/Source/src/modules/ModuleSceneManager.cpp
+++ b/Source/src/modules/ModuleSceneManager.cpp
@@ -138,8 +138,8 @@ void Hachiko::ModuleSceneManager::CheckSceneLoading()
 
     loading_scene_worker.join();
 
-    tmp_loading_scene->GetSkybox()->Reload();
     App->resources->PostLoadSceneResources();
+    tmp_loading_scene->GetSkybox()->Reload();
 
     PostLoadScene();
 


### PR DESCRIPTION
I think that with this pr the problem of the player getting a fall hit at the begining of the level is also solved. There is no much to test everything should feel the same. The main problem was that the correction applied to the player position was always fixed so if fps were low the delta time would increase and that would go through the threshold we had and the player would starts to fall if it walked to the edge or even sometimes some jump became imposible.

Also added in this PR:
- When boss is hitted its emissive is changed
- Beetles dont attack u more if player is dead
- Reorder the reloading of the skybox (that modifies the loading screen to half it size, so now the time when that happens are less)

For now I also made some changes to avoid crashes:
- Commented subscription of Particles to the SelectObject effect
- Try catch added to the Refresh label of component text