### PR TITLE
Forced emissive color on materials of lvl2

### DIFF
--- a/Game/assets/materials/ColumnArcBroken_mat.mat
+++ b/Game/assets/materials/ColumnArcBroken_mat.mat
@@ -6,7 +6,7 @@ metalness: 0
 emissive: 16763002857677931865
 diffuse_color: [0.588, 0.588, 0.588, 1]
 specular_color: [0.9, 0.9, 0.9, 1]
-emissive_color: [0, 0, 0, 1]
+emissive_color: [1, 1, 1, 1]
 smoothness: 0.5
 metalness_value: 0.5
 is_metallic: 1

--- a/Game/assets/materials/ColumnArcBroken_mat.mat.meta
+++ b/Game/assets/materials/ColumnArcBroken_mat.mat.meta
@@ -1,5 +1,5 @@
-asset_hash: 1537594326912412326
+asset_hash: 5331200779814849713
 resources:
   - resource_id: 5414009786853766812
     resource_type: 1
-    resource_hash: 1537594326912412326
+    resource_hash: 5331200779814849713

--- a/Game/assets/materials/ColumnArc_mat.mat
+++ b/Game/assets/materials/ColumnArc_mat.mat
@@ -6,7 +6,7 @@ metalness: 5640141114591955729
 emissive: 8726342794927297915
 diffuse_color: [0.588, 0.588, 0.588, 1]
 specular_color: [0.9, 0.9, 0.9, 1]
-emissive_color: [0, 0, 0, 1]
+emissive_color: [1, 1, 1, 1]
 smoothness: 0.5
 metalness_value: 0.5
 is_metallic: 0

--- a/Game/assets/materials/ColumnArc_mat.mat.meta
+++ b/Game/assets/materials/ColumnArc_mat.mat.meta
@@ -1,5 +1,5 @@
-asset_hash: 4631486138283307232
+asset_hash: 3501121867579462291
 resources:
   - resource_id: 13905282772193698380
     resource_type: 1
-    resource_hash: 4631486138283307232
+    resource_hash: 3501121867579462291

--- a/Game/assets/materials/shrine_mat.mat
+++ b/Game/assets/materials/shrine_mat.mat
@@ -6,7 +6,7 @@ metalness: 0
 emissive: 2506941208102516253
 diffuse_color: [0.588, 0.588, 0.588, 1]
 specular_color: [0.9, 0.9, 0.9, 1]
-emissive_color: [0, 0, 0, 1]
+emissive_color: [1, 1, 1, 1]
 smoothness: 0.5
 metalness_value: 0.5
 is_metallic: 0

--- a/Game/assets/materials/shrine_mat.mat.meta
+++ b/Game/assets/materials/shrine_mat.mat.meta
@@ -1,5 +1,5 @@
-asset_hash: 16158790238479018238
+asset_hash: 6076002752019771804
 resources:
   - resource_id: 16007776213478930409
     resource_type: 1
-    resource_hash: 16158790238479018238
+    resource_hash: 6076002752019771804


### PR DESCRIPTION
On lvl2 columns and shrine had emissive color at 0 and now I changed it to 1 so we can see the emissive texture