### PR TITLE
Improve serialization consistency

### DIFF
--- a/Source/src/components/ComponentTransform.cpp
+++ b/Source/src/components/ComponentTransform.cpp
@@ -164,6 +164,23 @@ void Hachiko::ComponentTransform::SetGlobalRotationEuler(const float3& new_rotat
     SetGlobalTransform(position, rotation, scale);
 }
 
+float3 Hachiko::ComponentTransform::AsConsistentEulerAngles(const float3& euler_angles) const
+{
+    float3 consistent_euler_angles = euler_angles;
+    FixEulerAngleSymbol(consistent_euler_angles.x);
+    FixEulerAngleSymbol(consistent_euler_angles.y);
+    FixEulerAngleSymbol(consistent_euler_angles.z);
+    return consistent_euler_angles;
+}
+
+void Hachiko::ComponentTransform::FixEulerAngleSymbol(float& euler_angle) const
+{
+    if (euler_angle == -180.f || euler_angle == -0.f)
+    {
+        euler_angle = abs(euler_angle);
+    }
+}
+
 
 /***    GETTERS     ***/
 
@@ -295,7 +312,7 @@ void Hachiko::ComponentTransform::Save(YAML::Node& node) const
 {
     node.SetTag("transform");
     node[TRANSFORM_POSITION] = local_position;
-    node[TRANSFORM_ROTATION] = local_rotation_euler;
+    node[TRANSFORM_ROTATION] = AsConsistentEulerAngles(local_rotation_euler);
     node[TRANSFORM_SCALE] = local_scale;
 }
 

--- a/Source/src/components/ComponentTransform.h
+++ b/Source/src/components/ComponentTransform.h
@@ -41,6 +41,8 @@ namespace Hachiko
         void SetGlobalRotation(const Quat& new_rotation);
         void SetGlobalRotationEuler(const float3& new_rotation_euler);
 
+        float3 AsConsistentEulerAngles(const float3& euler_angles) const;
+        void FixEulerAngleSymbol(float& euler_angle) const;
         [[nodiscard]] bool IsDirty() const
         {
             return dirty;

--- a/Source/src/components/ComponentTransform2D.cpp
+++ b/Source/src/components/ComponentTransform2D.cpp
@@ -247,7 +247,8 @@ void Hachiko::ComponentTransform2D::Save(YAML::Node& node) const
 {
     node.SetTag("transform_2d");
     node[TRANSFORM_POSITION] = position;
-    node[TRANSFORM_SIZE] = size;
+    // If a canvas is managing size prevent engine from keep updating transform size serialization
+    node[TRANSFORM_SIZE] = game_object->GetComponent<ComponentCanvas>() ? float2::one : size;
     node[TRANSFORM_SCALE] = scale.xy();
     node[TRANSFORM_ROTATION] = rotation;
     node[TRANSFORM_PIVOT] = pivot_pct_position;


### PR DESCRIPTION
**Changes**

- 0 and 180 angles will always be stored as positive
- Transform2d that has a canvas will store a const value because it keeps changing per save if we resize the scene viewport (Not ideal but should do the trick without changing save & load param structure)