### PR TITLE
Implement gauntlets easy mode

### DIFF
--- a/Gameplay/entities/enemies/BossController.cpp
+++ b/Gameplay/entities/enemies/BossController.cpp
@@ -468,7 +468,7 @@ void Hachiko::Scripting::BossController::FinishCocoon()
     std::copy(_jumping_pattern_2, _jumping_pattern_2 + JumpUtil::JUMP_PATTERN_SIZE, _current_jumping_pattern);
     _jump_pattern_index = -1;
 
-    gauntlet->ResetGauntlet();
+    gauntlet->ResetGauntlet(true);
 
     ChangeStateText("Finished Cocoon.");
 

--- a/Gameplay/misc/GauntletManager.cpp
+++ b/Gameplay/misc/GauntletManager.cpp
@@ -46,7 +46,7 @@ void Hachiko::Scripting::GauntletManager::OnStart()
 	_level_manager = Scenes::GetLevelManager()->GetComponent<LevelManager>();
 	game_object->SetVisible(false, false);
 
-	ResetGauntlet();
+	ResetGauntlet(true);
 }
 
 void Hachiko::Scripting::GauntletManager::OnUpdate()
@@ -69,7 +69,7 @@ void Hachiko::Scripting::GauntletManager::OnUpdate()
 
 }
 
-void Hachiko::Scripting::GauntletManager::ResetGauntlet()
+void Hachiko::Scripting::GauntletManager::ResetGauntlet(bool complete_reset)
 {
 	CloseDoors();
 	for (GameObject* enemy_pack : _enemy_packs)
@@ -77,14 +77,19 @@ void Hachiko::Scripting::GauntletManager::ResetGauntlet()
 		_combat_manager->DeactivateEnemyPack(enemy_pack);
 	}
 	started = false;
-	current_round = 0;
+	
 	remaining_between_round_time = 0.f;
+
+	if (!complete_reset)
+	{
+		return;
+	}
+	current_round = 0;
 }
 
 void Hachiko::Scripting::GauntletManager::StartGauntlet()
 {
 	started = true;
-	current_round = 0;
 	SpawnRound(current_round);
 
 	// Notify level manager

--- a/Gameplay/misc/GauntletManager.h
+++ b/Gameplay/misc/GauntletManager.h
@@ -25,7 +25,7 @@ namespace Hachiko
 			void OnAwake() override;
 			void OnStart() override;
 			void OnUpdate() override;
-			void ResetGauntlet();
+			void ResetGauntlet(bool complete_reset);
 			void StartGauntlet();
 			bool IsCompleted() const { return completed; }
 			bool IsFinished() const;

--- a/Gameplay/misc/LevelManager.cpp
+++ b/Gameplay/misc/LevelManager.cpp
@@ -13,6 +13,7 @@ Hachiko::Scripting::LevelManager::LevelManager(GameObject* game_object)
 	, _level(1)
 	, _respawn_position(float3::zero)
 	, _last_gauntlet(nullptr)
+	, _gauntlets_easy_mode(true)
 	, _modify_fog(false)
 	, _fog_frequency(0.1)
 	, _fog_max_density(0.015)
@@ -64,7 +65,9 @@ float3 Hachiko::Scripting::LevelManager::Respawn()
 {
 	if (_last_gauntlet != nullptr && !_last_gauntlet->IsCompleted())
 	{
-		_last_gauntlet->ResetGauntlet();
+		// If we play on easy mode do not reset gaunlets from first round
+		bool complete_reset_gauntlet = !_gauntlets_easy_mode;
+		_last_gauntlet->ResetGauntlet(complete_reset_gauntlet);
 	}
 
 	if (_audio_manager != nullptr)

--- a/Gameplay/misc/LevelManager.h
+++ b/Gameplay/misc/LevelManager.h
@@ -53,11 +53,14 @@ namespace Hachiko
 			SERIALIZE_FIELD(float3, _respawn_position);
 			SERIALIZE_FIELD(GameObject*, _gauntlet_ui_go);
 			SERIALIZE_FIELD(GameObject*, _gauntlet_counter_go);
+			SERIALIZE_FIELD(bool, _gauntlets_easy_mode);
 			SERIALIZE_FIELD(bool, _modify_fog);
 			SERIALIZE_FIELD(float, _fog_frequency);
 			SERIALIZE_FIELD(float, _fog_max_density);
 			SERIALIZE_FIELD(float, _fog_min_density);
 			SERIALIZE_FIELD(GameObject*, _audio_manager_go);
+			
+
 
 		private:
 			GauntletManager* _last_gauntlet = nullptr;


### PR DESCRIPTION
When you die gauntlet resets from current round and not all of them.
You can toggle this in level manager, turned on by default.