### PR TITLE
Small adjustments

### DIFF
--- a/Gameplay/entities/crystals/Stalagmite.cpp
+++ b/Gameplay/entities/crystals/Stalagmite.cpp
@@ -18,7 +18,7 @@ void Hachiko::Scripting::Stalagmite::ActiveEffects()
 	_explosion_effect->SetActive(true);
 }
 
-void Hachiko::Scripting::Stalagmite::Falling(float fall_progress, GameObject* player)
+void Hachiko::Scripting::Stalagmite::Falling(float fall_progress, const GameObject* player)
 {
 	float3 _stalagmite_position = GEO->GetTransform()->GetLocalPosition();
 

--- a/Gameplay/entities/crystals/Stalagmite.cpp
+++ b/Gameplay/entities/crystals/Stalagmite.cpp
@@ -18,20 +18,29 @@ void Hachiko::Scripting::Stalagmite::ActiveEffects()
 	_explosion_effect->SetActive(true);
 }
 
-void Hachiko::Scripting::Stalagmite::Falling(float fall_progress)
+void Hachiko::Scripting::Stalagmite::Falling(float fall_progress, GameObject* player)
 {
-	float3 _stalagmite_position = GEO
-		->GetComponent<ComponentTransform>()->GetLocalPosition();
+	float3 _stalagmite_position = GEO->GetTransform()->GetLocalPosition();
 
 	_stalagmite_position.y = Lerp(50.f, 0.f, fall_progress);
 
 
-	GEO->GetComponent<ComponentTransform>()
-		->SetLocalPosition(_stalagmite_position);
+	GEO->GetTransform()->SetLocalPosition(_stalagmite_position);
 
 	if (fall_progress == 1.f)
 	{
 		_obstacle_comp->AddObstacle();
+
+		float3 player_pos = player->GetTransform()->GetGlobalPosition();
+		float3 stalagmite_pos = _obstacle_comp->GetGameObject()->GetTransform()->GetGlobalPosition();
+		stalagmite_pos.y = player_pos.y;
+		if (Distance(player_pos, stalagmite_pos) <= 2.0f)
+		{
+			float dir_module = (player_pos - stalagmite_pos).Normalize();
+			float3 dir = (player_pos - stalagmite_pos).Normalized() * (2.0f - dir_module);
+			float3 corrected_position = Navigation::GetCorrectedPosition(player_pos + dir, float3(2.0f, 2.0f, 2.0f));
+			player->GetTransform()->SetGlobalPosition(corrected_position);
+		}
 	}
 }
 

--- a/Gameplay/entities/crystals/Stalagmite.h
+++ b/Gameplay/entities/crystals/Stalagmite.h
@@ -55,7 +55,7 @@ namespace Hachiko
 
 			void ActiveStalagmite();
 			void ActiveEffects();
-			void Falling(float fall_progress, GameObject* player);
+			void Falling(float fall_progress, const GameObject* player);
 
 			bool IsStalagmiteCollapsed() 
 			{

--- a/Gameplay/entities/crystals/Stalagmite.h
+++ b/Gameplay/entities/crystals/Stalagmite.h
@@ -55,7 +55,7 @@ namespace Hachiko
 
 			void ActiveStalagmite();
 			void ActiveEffects();
-			void Falling(float fall_progress);
+			void Falling(float fall_progress, GameObject* player);
 
 			bool IsStalagmiteCollapsed() 
 			{

--- a/Gameplay/entities/enemies/BossController.cpp
+++ b/Gameplay/entities/enemies/BossController.cpp
@@ -770,6 +770,15 @@ void Hachiko::Scripting::BossController::ExecuteJumpingState()
     {
         if (_jumping_timer < _jump_start_delay)
         {
+            if (_current_jumping_mode == JumpingMode::CRYSTAL)
+            {
+                game_object->GetTransform()->LookAtTarget(_crystal_jump_position);
+            }
+            else
+            {
+                game_object->GetTransform()->LookAtTarget(player->GetTransform()->GetGlobalPosition());
+            }
+
             // Boss is waiting for jump here:
             break;
         }
@@ -798,6 +807,7 @@ void Hachiko::Scripting::BossController::ExecuteJumpingState()
                 _jump_end_position + jump_direction * _jump_offset;
             _jump_end_position.y = _jump_start_position.y;
         }
+        game_object->GetTransform()->LookAtTarget(_jump_end_position);
 
         // Calculate mid position (only x and z is significant, z is ignored as
         // height is calculated separately), to avoid recalculation each frame

--- a/Gameplay/entities/enemies/BossController.cpp
+++ b/Gameplay/entities/enemies/BossController.cpp
@@ -368,7 +368,6 @@ void Hachiko::Scripting::BossController::StartEncounter()
     RestoreCameraOffset();
 
     obstacle->RemoveObstacle();
-    agent->AddToCrowd();
 }
 
 void Hachiko::Scripting::BossController::StartEncounterController()
@@ -380,6 +379,7 @@ void Hachiko::Scripting::BossController::StartEncounterController()
         return;
     }
     SetHpBarActive(true);
+    agent->AddToCrowd();
 
     player_camera->SetDoLookAhead(true);
     BreakCocoon();

--- a/Gameplay/entities/enemies/EnemyController.cpp
+++ b/Gameplay/entities/enemies/EnemyController.cpp
@@ -1101,7 +1101,7 @@ void Hachiko::Scripting::EnemyController::StartParasiteState()
 void Hachiko::Scripting::EnemyController::UpdateParasiteState()
 {
 	float transition = math::Sqrt(_parasite_dissolve_time - _parasite_dissolving_time_progress) * _parasite_dissolving;
-	_parasite->ChangeTintColor(float4(1.0f, 1.0f, 1.0f, transition), true);
+	_parasite->ChangeDissolveProgress(transition, true);
 	_parasite_dissolving_time_progress += Time::DeltaTimeScaled();
 }
 

--- a/Gameplay/misc/Centipedes.cpp
+++ b/Gameplay/misc/Centipedes.cpp
@@ -19,6 +19,7 @@ void Hachiko::Scripting::Centipedes::OnAwake()
 
 	animation->StartAnimating();
 	agent->SetMaxSpeed(3.0f);
+	agent->SetRadius(0.1f);
 }
 
 void Hachiko::Scripting::Centipedes::OnUpdate()
@@ -58,7 +59,7 @@ void Hachiko::Scripting::Centipedes::OnUpdate()
 		else
 		{
 			float3 new_destination = player_position + player_to_centipide.Normalized() * player_range;
-			Quat target_rotation = Quat::LookAt(float3(-1, 0, 0), player_transform->GetFront(), float3(0, 1, 0), float3(0, 1, 0));
+			Quat target_rotation = Quat::LookAt(float3(-1, 0, 0), (position - player_transform->GetGlobalPosition()).Normalized(), float3(0, 1, 0), float3(0, 1, 0));
 			Quat rotation = Quat::Slerp(game_object->GetTransform()->GetGlobalRotation(), target_rotation, Min(Time::DeltaTime() / Max(rotation_smoothness, 0.000001f), 1.0f));
 
 			game_object->GetTransform()->SetGlobalRotation(rotation);

--- a/Gameplay/misc/LevelManager.cpp
+++ b/Gameplay/misc/LevelManager.cpp
@@ -62,7 +62,7 @@ void Hachiko::Scripting::LevelManager::OnUpdate()
 		_gauntlet_ui_go->SetActive(_last_gauntlet && !_last_gauntlet->IsCompleted());
 	}
 
-	if (_victory && Input::IsKeyPressed(Input::KeyCode::KEY_SPACE))
+	if (_victory && (Input::IsKeyPressed(Input::KeyCode::KEY_SPACE) || Input::IsGameControllerButtonDown(Input::GameControllerButton::CONTROLLER_BUTTON_A)))
 	{
 		SceneManagement::SwitchScene(Scenes::MAIN_MENU);
 	}

--- a/Gameplay/misc/StalagmiteManager.cpp
+++ b/Gameplay/misc/StalagmiteManager.cpp
@@ -187,7 +187,7 @@ void Hachiko::Scripting::StalagmiteManager::UpdateStalagmiteState(Stalagmite* st
 
 void Hachiko::Scripting::StalagmiteManager::FallingStalagmite(Stalagmite* stalagmite, float fall_progress)
 {
-	stalagmite->Falling(fall_progress);
+	stalagmite->Falling(fall_progress, _player);
 }
 
 void Hachiko::Scripting::StalagmiteManager::TriggerStalagmites()

--- a/Source/src/modules/ModuleRender.cpp
+++ b/Source/src/modules/ModuleRender.cpp
@@ -518,6 +518,9 @@ bool Hachiko::ModuleRender::DrawToShadowMap(
     // Bind shadow map fbo for drawing and adjust viewport size etc.:
     shadow_manager.BindBufferForDrawing();
 
+    //Disable to cull for both faces
+    glDisable(GL_CULL_FACE);
+
     if ((draw_config & DRAW_CONFIG_OPAQUE) != 0)
     {
         // Collect and draw opaque meshes to shadow map:
@@ -555,6 +558,9 @@ bool Hachiko::ModuleRender::DrawToShadowMap(
 
         batch_manager->DrawTransparentBatches(program);
     }
+
+    //Enable back to face culling
+    glEnable(GL_CULL_FACE);
 
     // Unbind shadow map fbo:
     ShadowManager::UnbindBuffer();


### PR DESCRIPTION
Som adjustments done in the pr:

- Boss jump looking to the target
- Boss does not move at the start of the encounter
- Parasite material opaque and uses disolve effect
- Disable face culling for computing shadows
- Victory screen skippable with space and controller A
- Centipedes agent raidus + look at correction
- Stalamites dont make the player fall to the void