### PR TITLE
Fix worm spawn onstart

### DIFF
--- a/Source/src/components/ComponentParticleSystem.cpp
+++ b/Source/src/components/ComponentParticleSystem.cpp
@@ -75,6 +75,8 @@ void Hachiko::ComponentParticleSystem::Start()
     };
     App->event->Subscribe(Event::Type::SELECTION_CHANGED, selection_changed, GetID());*/
     emitter_state = ParticleSystem::Emitter::State::PLAYING;
+
+    initialized = true;
 }
 
 void Hachiko::ComponentParticleSystem::Update()
@@ -833,7 +835,10 @@ void Hachiko::ComponentParticleSystem::Pause()
 
 void Hachiko::ComponentParticleSystem::Restart()
 {
-    Reset();
+    if (initialized)
+    {
+        Reset();
+    }
     emitter_state = ParticleSystem::Emitter::State::PLAYING;
 }
 

--- a/Source/src/components/ComponentParticleSystem.h
+++ b/Source/src/components/ComponentParticleSystem.h
@@ -49,6 +49,7 @@ namespace Hachiko
         HACHIKO_API void Stop() override;
 
     private:
+        bool initialized = false;
         ParticleSystem::Emitter::State emitter_state = ParticleSystem::Emitter::State::STOPPED;
 
         //sections

--- a/Source/src/modules/ModuleWindow.cpp
+++ b/Source/src/modules/ModuleWindow.cpp
@@ -44,7 +44,13 @@ bool Hachiko::ModuleWindow::Init()
         }
 
         App->renderer->SetOpenGLAttributes();
+
+#ifdef PLAY_BUILD
+        window = SDL_CreateWindow("Emiros", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags);
+#else
         window = SDL_CreateWindow(TITLE, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags);
+#endif // PLAY_BUILD
+
 
         if (window == nullptr)
         {

--- a/Source/src/modules/ModuleWindow.cpp
+++ b/Source/src/modules/ModuleWindow.cpp
@@ -46,7 +46,7 @@ bool Hachiko::ModuleWindow::Init()
         App->renderer->SetOpenGLAttributes();
 
 #ifdef PLAY_BUILD
-        window = SDL_CreateWindow("Emiros", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags);
+        window = SDL_CreateWindow("Erimos", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags);
 #else
         window = SDL_CreateWindow(TITLE, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags);
 #endif // PLAY_BUILD


### PR DESCRIPTION
On PLAY_BUILD in the second level was reseting a particle system without this one being initialized.
Also change the window name to emiros when built in PLAY_BUILD, it would be cool to change the icon too.