### PR TITLE
Improvement/beetle attack

### DIFF
--- a/Gameplay/entities/enemies/EnemyController.h
+++ b/Gameplay/entities/enemies/EnemyController.h
@@ -292,6 +292,8 @@ namespace Hachiko
             SERIALIZE_FIELD(float, damage_effect_duration);
             float damage_effect_progress = 0.0f;
 
+            bool _attacking = false;
+
             bool _valid_path = false;
             float _timer_check_path = 0.0f;
 

--- a/Gameplay/entities/player/PlayerController.cpp
+++ b/Gameplay/entities/player/PlayerController.cpp
@@ -1025,6 +1025,10 @@ void Hachiko::Scripting::PlayerController::MovementController()
 			// Fall dmg
 			RegisterHit(1, 0, float3::zero, true, DamageType::FALL);
 
+			// Empty the buffer action
+			_remaining_buffer_time = 0.0f;
+			dash_buffer = false;
+
 			// If its still alive place it in the first valid position, if none exists respawn it
 			_player_position = GetLastValidDashOrigin();
 			if (_player_position.x >= FLT_MAX)

--- a/Source/src/components/ComponentAnimation.cpp
+++ b/Source/src/components/ComponentAnimation.cpp
@@ -112,7 +112,7 @@ std::string Hachiko::ComponentAnimation::GetActiveNode() const
 
 void Hachiko::ComponentAnimation::Update()
 {
-    controller->Update(EngineTimer::delta_time * 1000, reverse);
+    controller->Update(EngineTimer::delta_time * 1000 * speed, reverse);
 
     if (game_object != nullptr)
     {

--- a/Source/src/components/ComponentAnimation.h
+++ b/Source/src/components/ComponentAnimation.h
@@ -36,6 +36,10 @@ namespace Hachiko
             return controller->GetCurrentState() == AnimationController::State::STOPPED;
         }
 
+        HACHIKO_API void SetSpeed(float new_speed)
+        {
+            speed = new_speed;
+        }
 
         // TEST
         bool reverse = false;
@@ -53,6 +57,8 @@ namespace Hachiko
     private:
         AnimationController* controller = nullptr;
         unsigned int active_node = 0;
+
+        float speed = 1.0f;
 
         // SM CONTROL
         WindowStateMachine* windowStateMachine = nullptr;


### PR DESCRIPTION
As @Bernatmago requested, now the beetles don't attack instantly they slow the attack animation down to give some anticipation to the attack.
Also hitting the enemy makes it cancel its attack.

Please test it in depth thx.

Edit: to not open another pr i also emptied the player buffers on fall so if you fall and spam dash you dont fall again