### PR TITLE
Levelmanager fog by height config

### DIFF
--- a/Gameplay/misc/LevelManager.cpp
+++ b/Gameplay/misc/LevelManager.cpp
@@ -21,6 +21,9 @@ Hachiko::Scripting::LevelManager::LevelManager(GameObject* game_object)
 	, _fog_frequency(0.1)
 	, _fog_max_density(0.015)
 	, _fog_min_density(0.005)
+	, _modify_fog_by_height(false)
+	, _player_height(float2::zero)
+	, _fog_height(float2::zero)
 {}
 
 void Hachiko::Scripting::LevelManager::OnAwake()
@@ -52,6 +55,7 @@ void Hachiko::Scripting::LevelManager::OnAwake()
 	}
 
 	_time = 0;
+	_player_transform = Scenes::GetPlayer()->GetTransform();
 }
 
 void Hachiko::Scripting::LevelManager::OnUpdate()
@@ -63,6 +67,12 @@ void Hachiko::Scripting::LevelManager::OnUpdate()
 		float avg_density = (_fog_min_density + _fog_max_density) / 2;
 		float amp_density = (_fog_max_density - _fog_min_density) / 2;
 		SceneManagement::SetFogGlobalDensity(avg_density + amp_density * (math::Sin(_time * _fog_frequency * math::pi * 2)));
+	}
+	else if (_modify_fog_by_height)
+	{
+		float delta_fog_height = (_fog_height.y - _fog_height.x) / (_player_height.y - _player_height.x);
+		float fog_height = _fog_height.x + (_player_transform->GetGlobalPosition().y - _player_height.x) * delta_fog_height;
+		SceneManagement::SetFogHeightFalloff(fog_height);
 	}
 
 	if (_last_gauntlet) 

--- a/Gameplay/misc/LevelManager.h
+++ b/Gameplay/misc/LevelManager.h
@@ -62,6 +62,9 @@ namespace Hachiko
 			SERIALIZE_FIELD(float, _fog_frequency);
 			SERIALIZE_FIELD(float, _fog_max_density);
 			SERIALIZE_FIELD(float, _fog_min_density);
+			SERIALIZE_FIELD(bool, _modify_fog_by_height);
+			SERIALIZE_FIELD(float2, _player_height);
+			SERIALIZE_FIELD(float2, _fog_height);
 			SERIALIZE_FIELD(GameObject*, _audio_manager_go);
 			SERIALIZE_FIELD(GameObject*, _player_sound_manager_go);
 			SERIALIZE_FIELD(GameObject*, _victory_screen);
@@ -69,6 +72,7 @@ namespace Hachiko
 			static bool increased_health;
 			
 		private:
+			ComponentTransform* _player_transform = nullptr;
 			GauntletManager* _last_gauntlet = nullptr;
 			ComponentText* _enemy_counter = nullptr;
 			AudioManager* _audio_manager = nullptr;


### PR DESCRIPTION
On the level manager there are 3 attributes:
- Modify fog by height -> activate
- Player height ->x: minimum player height - y: maximum player height
- Fog height -> x: value of fog height falloff when player is on Player_height.x - y: same but y

![image](https://user-images.githubusercontent.com/52320536/199332486-e340d108-6388-40e4-bbc6-cef1b69842c1.png)
