### PR TITLE
Some small fixes gauntlets

### DIFF
--- a/Gameplay/entities/enemies/EnemyController.cpp
+++ b/Gameplay/entities/enemies/EnemyController.cpp
@@ -552,6 +552,12 @@ void Hachiko::Scripting::EnemyController::ResetEnemyPosition()
 	transform->SetGlobalRotation(_spawn_rot);
 }
 
+void Hachiko::Scripting::EnemyController::ResetEnemyAgent()
+{
+	_component_agent->SetTargetPosition(_spawn_pos);
+	_component_agent->RemoveFromCrowd();
+}
+
 /*
 	THE BUG IS USING THIS STAE MACHINE SYSTEM WHERE EACH STATE HAS 4 METHODS:
 	- START: EXECUTED WHEN THE STATE IS CHANGED

--- a/Gameplay/entities/enemies/EnemyController.h
+++ b/Gameplay/entities/enemies/EnemyController.h
@@ -72,6 +72,7 @@ namespace Hachiko
 
             void ResetEnemy();
             void ResetEnemyPosition();
+            void ResetEnemyAgent();
 
         private:
             void GetComponents();

--- a/Gameplay/entities/player/CombatManager.cpp
+++ b/Gameplay/entities/player/CombatManager.cpp
@@ -626,6 +626,7 @@ void Hachiko::Scripting::CombatManager::ResetEnemyPack(GameObject* pack, bool is
 			enemy_controller->SetIsFromGauntlet(is_gauntlet);
 			enemy_controller->ResetEnemy();
 			enemy_controller->ResetEnemyPosition();
+			enemy_controller->ResetEnemyAgent();
 			enemy_controller->OnStart();
 		}
 	}

--- a/Gameplay/misc/GauntletManager.cpp
+++ b/Gameplay/misc/GauntletManager.cpp
@@ -155,6 +155,9 @@ void Hachiko::Scripting::GauntletManager::StartGauntlet()
 		_closing_door->SetActive(true);
 		_closing_door->ChangeDissolveProgress(0.0f, true);
 	}
+
+	unsigned alive_count = _combat_manager->GetPackAliveCount(_enemy_packs[current_round]);
+	_level_manager->SetEnemyCount(alive_count);
 }
 
 bool Hachiko::Scripting::GauntletManager::IsFinished() const
@@ -164,7 +167,8 @@ bool Hachiko::Scripting::GauntletManager::IsFinished() const
 
 void Hachiko::Scripting::GauntletManager::CheckRoundStatus()
 {
-	if (current_round >= _enemy_packs.size()) {
+	if (current_round >= _enemy_packs.size()) 
+	{
 		completed = true;
 		_elapsed_time = 0.0f;
 		OpenDoors();
@@ -178,7 +182,7 @@ void Hachiko::Scripting::GauntletManager::CheckRoundStatus()
 
 	_level_manager->SetEnemyCount(alive_count);
 
-	if(alive_count > 0) return;
+	if (alive_count > 0) return;
 
 	if (!changing_rounds)
 	{

--- a/Gameplay/misc/LevelManager.cpp
+++ b/Gameplay/misc/LevelManager.cpp
@@ -65,9 +65,10 @@ void Hachiko::Scripting::LevelManager::OnUpdate()
 		SceneManagement::SetFogGlobalDensity(avg_density + amp_density * (math::Sin(_time * _fog_frequency * math::pi * 2)));
 	}
 
-	if (_last_gauntlet) 
+	if (_last_gauntlet && _last_gauntlet->IsCompleted())
 	{
-		_gauntlet_ui_go->SetActive(_last_gauntlet && !_last_gauntlet->IsCompleted());
+		_gauntlet_ui_go->SetActive(false);
+		_last_gauntlet = nullptr;
 	}
 
 	if (_victory && (Input::IsKeyPressed(Input::KeyCode::KEY_SPACE) || Input::IsGameControllerButtonDown(Input::GameControllerButton::CONTROLLER_BUTTON_A)))
@@ -79,6 +80,7 @@ void Hachiko::Scripting::LevelManager::OnUpdate()
 void Hachiko::Scripting::LevelManager::SetGauntlet(GauntletManager* last_gauntlet)
 {
 	_last_gauntlet = last_gauntlet;
+	_gauntlet_ui_go->SetActive(_last_gauntlet && !_last_gauntlet->IsCompleted());
 }
 
 void Hachiko::Scripting::LevelManager::SetEnemyCount(unsigned count)
@@ -100,9 +102,9 @@ float3 Hachiko::Scripting::LevelManager::Respawn()
 		_audio_manager->Restart();
 	}
 
-	return GetRespawnPosition();
+	_gauntlet_ui_go->SetActive(false);
 
-	//Disable gauntlet ui
+	return GetRespawnPosition();
 }
 
 void Hachiko::Scripting::LevelManager::ReloadBossScene() const {


### PR DESCRIPTION
- Fix enemies spawning the second time somewhere else, now enemies always spawn in the same position
- Gauntlet ui only shown in the gaunlet (deactivated on death)
- Gauntlet ui updates instantly with the enemy count (before you could see a 0 for a couple of seconds and the X enemies)