### PR TITLE
[FIX] Aim indicator was visible after falling

### DIFF
--- a/Gameplay/entities/player/PlayerController.cpp
+++ b/Gameplay/entities/player/PlayerController.cpp
@@ -1141,6 +1141,8 @@ void Hachiko::Scripting::PlayerController::MovementController()
 		// Started falling
 		if (!IsFalling())
 		{
+			CancelAttack();
+
 			_start_fall_pos = _player_position;
 			_state = PlayerState::FALLING;
 		}


### PR DESCRIPTION
Go to crystal platform, aim, dont shoot, fall, see how the indicator is still there, beat me up to death, spit ton my corpse. Everyone happy but me, because I'm dead, and its all your fault. 