### PR TITLE
Fix error when coming from level2 to boss

### DIFF
--- a/Gameplay/entities/enemies/BossController.cpp
+++ b/Gameplay/entities/enemies/BossController.cpp
@@ -9,6 +9,8 @@
 #include "constants/Scenes.h"
 #include "components/ComponentObstacle.h"
 #include "components/ComponentAudioSource.h"
+#include "components/ComponentProgressBar.h"
+#include "components/ComponentImage.h"
 #include "constants/Sounds.h"
 
 #include "entities/player/CombatVisualEffectsPool.h"

--- a/Gameplay/entities/enemies/BossController.h
+++ b/Gameplay/entities/enemies/BossController.h
@@ -18,6 +18,7 @@ namespace Hachiko
     class ComponentProgressBar;
     class ComponentObstacle;
     class ComponentAudioSource;
+    class ComponentImage;
 
 	namespace Scripting
 	{

--- a/Source/src/components/ComponentProgressBar.h
+++ b/Source/src/components/ComponentProgressBar.h
@@ -67,12 +67,20 @@ namespace Hachiko
 
         [[nodiscard]] GameObject* GetBackground() const
         {
-            return background;
+            if (game_object->children.size() < 2)
+            {
+                return nullptr;
+            }
+            return game_object->children[0];
         }
 
         [[nodiscard]] GameObject* GetFill() const
         {
-            return fill;
+            if (game_object->children.size() < 2)
+            {
+                return nullptr;
+            }
+            return game_object->children[1];
         }
 
         void Save(YAML::Node& node) const override;


### PR DESCRIPTION
@Erick9Thor found out that when going from level 2 to boss scene an error was jumping.
BossController was trying to get progressBar fill image before this one initialized.